### PR TITLE
Add reference for viewing docker logs and scanner erroring

### DIFF
--- a/docs/Troubleshooting/Miscellaneous-Troubleshooting.md
+++ b/docs/Troubleshooting/Miscellaneous-Troubleshooting.md
@@ -14,3 +14,7 @@ Verify that the database is mapped to a persistent storage volume in your docker
 ### Error: `Could not get twitch auth token: check client_id and client_secret`
 
 This is likely due to mis-configured environment variables; verify that `CLIENT_ID` and `CLIENT_SECRET` are set correctly, and that both match the values in IGDB.
+
+### How to view RomM logs to assist with troubleshooting
+
+Each platform may have different logs, but check the stdout logs for docker. For example when using the recommended docker compose setup `docker logs -f romm` will display a continuous stream of the log. Most lines start with `INFO`, `WARNING`, or `ERROR`

--- a/docs/Troubleshooting/Scanning-Issues.md
+++ b/docs/Troubleshooting/Scanning-Issues.md
@@ -25,3 +25,7 @@ When scanning the folders mounted in `/library/roms`, the scanner tries to match
 ### Scan times out after ~4 hours
 
 The background scan task times out after 4 hours, which can happen if you have a very large library. The easiest work around is to keep running scans every 4 hours, **without** checking the "Complete re-scan" option.
+
+### Scan stops before finishing a platform
+
+Check the logs for RomM, you should find a line that looks like `ERROR:    [RomM][scan_handler][2025-04-12 11:48:55]` that explains why the scanner stopped. This can often happen due to a corrupted file or a file the [python zipfile library](https://docs.python.org/3/library/zipfile.html) cannot handle, such as old DOS zip files with backslashes instead of forward slashes.


### PR DESCRIPTION
1. Added a section to misc troubleshooting for how to view docker logs
2. Added a section to scanning issues about the scanner aborting due to corrupted files or non-standard zip files