### PR TITLE
Update Scanning-Issues.md

### DIFF
--- a/docs/Troubleshooting/Scanning-Issues.md
+++ b/docs/Troubleshooting/Scanning-Issues.md
@@ -35,6 +35,7 @@ Check the logs for RomM, you should find a line that looks like `ERROR:    [RomM
 The easiest method is to check the logs via this command, which will list all the scanned platforms since the RomM container was started `docker logs romm 2>/dev/null|egrep 'scan_handler.*Identified as.*🎮'`
 
 Here is an example output:
+
 ```text
 $ docker logs romm 2>/dev/null|egrep 'scan_handler.*Identified as.*🎮'
 INFO:     [RomM][scan_handler][2025-04-12 11:37:40]   Identified as PlayStation 🎮

--- a/docs/Troubleshooting/Scanning-Issues.md
+++ b/docs/Troubleshooting/Scanning-Issues.md
@@ -24,8 +24,20 @@ When scanning the folders mounted in `/library/roms`, the scanner tries to match
 
 ### Scan times out after ~4 hours
 
-The background scan task times out after 4 hours, which can happen if you have a very large library. The easiest work around is to keep running scans every 4 hours, **without** checking the "Complete re-scan" option.
+The background scan task times out after 4 hours, which can happen if you have a very large library. The easiest work around is to keep running scans every 4 hours, **without** checking the "Complete re-scan" option. You can also change the timeout via [environment variable](../Getting-Started/Environment-Variables.md) `SCAN_TIMEOUT`.
 
 ### Scan stops before finishing a platform
 
 Check the logs for RomM, you should find a line that looks like `ERROR:    [RomM][scan_handler][2025-04-12 11:48:55]` that explains why the scanner stopped. This can often happen due to a corrupted file or a file the [python zipfile library](https://docs.python.org/3/library/zipfile.html) cannot handle, such as old DOS zip files with backslashes instead of forward slashes.
+
+### When scanning a very large library with many platforms it is difficult to keep track of which systems have scanned in
+
+The easiest method is to check the logs via this command, which will list all the scanned platforms since the RomM container was started `docker logs romm 2>/dev/null|egrep 'scan_handler.*Identified as.*🎮'`
+
+Here is an example output:
+```
+$ docker logs romm 2>/dev/null|egrep 'scan_handler.*Identified as.*🎮'
+INFO:     [RomM][scan_handler][2025-04-12 11:37:40]   Identified as PlayStation 🎮
+INFO:     [RomM][scan_handler][2025-04-12 14:39:32]   Identified as DOS 🎮
+INFO:     [RomM][scan_handler][2025-04-13 12:50:42]   Identified as WonderSwan 🎮
+```

--- a/docs/Troubleshooting/Scanning-Issues.md
+++ b/docs/Troubleshooting/Scanning-Issues.md
@@ -35,7 +35,7 @@ Check the logs for RomM, you should find a line that looks like `ERROR:    [RomM
 The easiest method is to check the logs via this command, which will list all the scanned platforms since the RomM container was started `docker logs romm 2>/dev/null|egrep 'scan_handler.*Identified as.*🎮'`
 
 Here is an example output:
-```
+```text
 $ docker logs romm 2>/dev/null|egrep 'scan_handler.*Identified as.*🎮'
 INFO:     [RomM][scan_handler][2025-04-12 11:37:40]   Identified as PlayStation 🎮
 INFO:     [RomM][scan_handler][2025-04-12 14:39:32]   Identified as DOS 🎮


### PR DESCRIPTION
1. Add blurb to scan timeouts referencing the SCAN_TIMEOUT environment variables
2. Add new section that lists a command to see the platforms scanned in. Useful for first time setup of very large collections.