### PR TITLE
Create Kubernetes-Issues.md

### DIFF
--- a/docs/Troubleshooting/Kubernetes-Issues.md
+++ b/docs/Troubleshooting/Kubernetes-Issues.md
@@ -1,0 +1,26 @@
+---
+title: Kubernetes Troubleshooting
+description: Troubleshooting Kubernetes issues
+---
+
+### Error: `invalid host in "tcp://<internal ip>:8080" of the "listen" directive in /etc/nginx/conf.d/default.conf:7`
+
+By default, Kubernetes will grab information about the service object linked to a pod and inject it as an environment variable into the pod. In RomM, this leads to the pod attempting to bind to the service IP address, leading to the above fatal error.
+
+To resolve thes error, this default Kubernetes behaviour needs to be disabled by setting the `enableServiceLinks` value in the pod spec to `false`.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: romm
+  namespace: romm
+  ...
+spec:
+  ...
+  template:
+    ...
+    spec:
+      enableServiceLinks: false
+      ...
+```


### PR DESCRIPTION
This pull request documents a fix to an issue running the docker image in Kubernetes due to the default value of `enableServiceLinks` in the Kubernetes pod spec.

I was facing this issue but was only able to find the solution by joining the discord and seeing a number of people reporting the same issue. As it seems to be a frequently asked question, it makes sense to document the solution in the official docs.