### PR TITLE
Correct log level environment variable on observability page

### DIFF
--- a/docs/administration/observability.md
+++ b/docs/administration/observability.md
@@ -16,7 +16,7 @@ It's often handy to know what's happening under the hood, especially when debugg
 
 ```yaml
 environment:
-    - LOG_LEVEL=INFO # DEBUG | INFO | WARNING | ERROR
+    - LOGLEVEL=INFO # DEBUG | INFO | WARNING | ERROR
     - FORCE_COLOR=0 # 1 to force colour even when not a TTY
     - NO_COLOR=1 # 1 to disable colour entirely
 ```


### PR DESCRIPTION
The documented variable name on the Observability page is `LOG_LEVEL` but the correct environment variable, referenced in RomM code and in `env-vars.md`, is `LOGLEVEL`. This caused me a bit of confusion trying to debug a different issue :sweat_smile: 