### PR TITLE
docs: cover RomM 5.0.0-beta.1 config, auth, and admin changes

### DIFF
--- a/docs/administration/authentication.md
+++ b/docs/administration/authentication.md
@@ -61,7 +61,7 @@ environment:
     - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
 ```
 
-When OIDC is configured, an OIDC sign-in option is offered alongside username/password. Set `OIDC_AUTOLOGIN=true` to redirect straight to the IdP without the user having to choose. By default the first login for an unknown email auto-creates an account; set `OIDC_ALLOW_REGISTRATION=false` to allow only pre-provisioned users in. See [OIDC Setup](oidc/index.md) for role mapping and auto-provisioning.
+When OIDC is configured, an OIDC sign-in option is offered alongside username/password. Set `OIDC_AUTOLOGIN=true` to redirect straight to the IdP without the user having to choose. By default the first login for an unknown email auto-creates an account; set `OIDC_ALLOW_REGISTRATION=false` to allow only pre-provisioned users in (see [OIDC Setup](oidc/index.md) for role mapping and auto-provisioning).
 
 ## Client API Tokens
 

--- a/docs/administration/authentication.md
+++ b/docs/administration/authentication.md
@@ -36,7 +36,7 @@ Local accounts are created via [invitations, registration, admin setup, or the S
 
 ```yaml
 environment:
-    - DISABLE_USERPASS_LOGIN=true
+  - DISABLE_USERPASS_LOGIN=true
 ```
 
 <!-- prettier-ignore -->
@@ -53,15 +53,15 @@ See [OIDC Setup](oidc/index.md) for the full walkthrough. One-liner config sketc
 
 ```yaml
 environment:
-    - OIDC_ENABLED=true
-    - OIDC_PROVIDER=keycloak
-    - OIDC_CLIENT_ID=...
-    - OIDC_CLIENT_SECRET=...
-    - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
-    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+  - OIDC_ENABLED=true
+  - OIDC_PROVIDER=keycloak
+  - OIDC_CLIENT_ID=...
+  - OIDC_CLIENT_SECRET=...
+  - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
+  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
 ```
 
-When OIDC is configured, an OIDC sign-in option is offered alongside username/password. Set `OIDC_AUTOLOGIN=true` to redirect straight to the IdP without the user having to choose.
+When OIDC is configured, an OIDC sign-in option is offered alongside username/password. Set `OIDC_AUTOLOGIN=true` to redirect straight to the IdP without the user having to choose. By default the first login for an unknown email auto-creates an account; set `OIDC_ALLOW_REGISTRATION=false` to allow only pre-provisioned users in. See [OIDC Setup](oidc/index.md) for role mapping and auto-provisioning.
 
 ## Client API Tokens
 
@@ -80,7 +80,7 @@ Grants unauthenticated, read-only access to nearly every GET endpoint. Anyone re
 
 ```yaml
 environment:
-    - KIOSK_MODE=true
+  - KIOSK_MODE=true
 ```
 
 Appropriate for:
@@ -89,13 +89,13 @@ Appropriate for:
 - Public-facing "display" instances
 - `demo.romm.app`
 
-Authenticated users (when you do sign in) will still see the full UI with all actions available to their role.
+Authenticated users (when you do sign in) will still see the full UI with all actions available to their role and [permission group](users-and-roles.md#permission-groups).
 
 ## Download-endpoint auth bypass
 
 ```yaml
 environment:
-    - DISABLE_DOWNLOAD_ENDPOINT_AUTH=true
+  - DISABLE_DOWNLOAD_ENDPOINT_AUTH=true
 ```
 
 Skips auth on `GET /api/roms/{id}/content/…` and the firmware download endpoint. Exists so third-party apps that can't carry a bearer header (like dumb emulators loading a ROM by URL) can still pull files. **Only enable this when the public internet can't reach RomM directly**, i.e. there's auth or an IP allowlist at the reverse-proxy layer. Otherwise you've just made your library world-downloadable.

--- a/docs/administration/authentication.md
+++ b/docs/administration/authentication.md
@@ -36,7 +36,7 @@ Local accounts are created via [invitations, registration, admin setup, or the S
 
 ```yaml
 environment:
-  - DISABLE_USERPASS_LOGIN=true
+    - DISABLE_USERPASS_LOGIN=true
 ```
 
 <!-- prettier-ignore -->
@@ -53,12 +53,12 @@ See [OIDC Setup](oidc/index.md) for the full walkthrough. One-liner config sketc
 
 ```yaml
 environment:
-  - OIDC_ENABLED=true
-  - OIDC_PROVIDER=keycloak
-  - OIDC_CLIENT_ID=...
-  - OIDC_CLIENT_SECRET=...
-  - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
-  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+    - OIDC_ENABLED=true
+    - OIDC_PROVIDER=keycloak
+    - OIDC_CLIENT_ID=...
+    - OIDC_CLIENT_SECRET=...
+    - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
+    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
 ```
 
 When OIDC is configured, an OIDC sign-in option is offered alongside username/password. Set `OIDC_AUTOLOGIN=true` to redirect straight to the IdP without the user having to choose. By default the first login for an unknown email auto-creates an account; set `OIDC_ALLOW_REGISTRATION=false` to allow only pre-provisioned users in. See [OIDC Setup](oidc/index.md) for role mapping and auto-provisioning.
@@ -80,7 +80,7 @@ Grants unauthenticated, read-only access to nearly every GET endpoint. Anyone re
 
 ```yaml
 environment:
-  - KIOSK_MODE=true
+    - KIOSK_MODE=true
 ```
 
 Appropriate for:
@@ -95,7 +95,7 @@ Authenticated users (when you do sign in) will still see the full UI with all ac
 
 ```yaml
 environment:
-  - DISABLE_DOWNLOAD_ENDPOINT_AUTH=true
+    - DISABLE_DOWNLOAD_ENDPOINT_AUTH=true
 ```
 
 Skips auth on `GET /api/roms/{id}/content/…` and the firmware download endpoint. Exists so third-party apps that can't carry a bearer header (like dumb emulators loading a ROM by URL) can still pull files. **Only enable this when the public internet can't reach RomM directly**, i.e. there's auth or an IP allowlist at the reverse-proxy layer. Otherwise you've just made your library world-downloadable.

--- a/docs/administration/index.md
+++ b/docs/administration/index.md
@@ -13,7 +13,7 @@ The end-user equivalent (how to actually play the games, build collections, uplo
 
 ### Users & access
 
-- **[Users & Roles](users-and-roles.md)**: roles, the scope model, how permissions add up
+- **[Users & Roles](users-and-roles.md)**: roles, permission groups, per-user overrides, and hidden entities
 - **[Invitations & Registration](invitations-and-registration.md)**: invite links, public signup, first-user setup
 - **[Authentication](authentication.md)**: session config, password reset, Client API Tokens for devices
 - **[OIDC Setup](oidc/index.md)**: Authelia, Authentik, Keycloak, PocketID, Zitadel, VoidAuth, SSO + role mapping

--- a/docs/administration/invitations-and-registration.md
+++ b/docs/administration/invitations-and-registration.md
@@ -28,7 +28,7 @@ You'll then need to create the first admin via the API or by injecting a databas
 
 The recommended way to add users, because it avoids you ever touching their password.
 
-1. **Administration → Users → Invite.** Pick a role (User or Admin); for a User you can also pick a [permission group](users-and-roles.md#permission-groups).
+1. **Administration → Users → Invite.** Pick a role (User or Admin).
 2. RomM generates a single-use URL → copy it and send it to the invitee.
 3. When they open it, they pick their own username and password.
 4. RomM creates the account with the role you chose and logs them straight in.

--- a/docs/administration/invitations-and-registration.md
+++ b/docs/administration/invitations-and-registration.md
@@ -9,7 +9,7 @@ There are three ways a new account ends up on a RomM instance:
 
 1. **First-admin setup**: the person who completes the Setup Wizard.
 2. **Invite link**: an admin generates a one-shot link carrying a pre-assigned role.
-3. **OIDC auto-provisioning**: first login through your IdP creates a matching account (covered in [OIDC Setup](oidc/index.md)).
+3. **OIDC auto-provisioning**: first login through your IdP creates a matching account, unless you set `OIDC_ALLOW_REGISTRATION=false` (covered in [OIDC Setup](oidc/index.md)).
 
 ## First-admin setup
 
@@ -19,7 +19,7 @@ To skip the wizard (e.g. when provisioning via automation and you'll create user
 
 ```yaml
 environment:
-    - DISABLE_SETUP_WIZARD=true
+  - DISABLE_SETUP_WIZARD=true
 ```
 
 You'll then need to create the first admin via the API or by injecting a database row at deploy time, because the UI won't offer a setup flow.
@@ -28,7 +28,7 @@ You'll then need to create the first admin via the API or by injecting a databas
 
 The recommended way to add users, because it avoids you ever touching their password.
 
-1. **Administration → Users → Invite.** Pick a role (Viewer, Editor, Admin).
+1. **Administration → Users → Invite.** Pick a role (User or Admin); for a User you can also pick a [permission group](users-and-roles.md#permission-groups).
 2. RomM generates a single-use URL → copy it and send it to the invitee.
 3. When they open it, they pick their own username and password.
 4. RomM creates the account with the role you chose and logs them straight in.
@@ -43,11 +43,11 @@ Expired links return a clear error on the `/register` page. Generate a new one f
 
 ## Role assignment at sign-up
 
-| Sign-up method          | Role assigned                                                |
-| ----------------------- | ------------------------------------------------------------ |
-| First-user Setup Wizard | Admin (always)                                               |
-| Invite link             | Whatever role the admin picked when generating the link      |
-| OIDC first login        | Default Viewer, or mapped from claims via `OIDC_CLAIM_ROLES` |
+| Sign-up method          | Role assigned                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| First-user Setup Wizard | Admin (always)                                                                   |
+| Invite link             | Whatever role the admin picked when generating the link                          |
+| OIDC first login        | User (in the default permission group), or Admin if mapped via `OIDC_ROLE_ADMIN` |
 
 Changing a user's role afterwards is a normal admin action (see [Users & Roles](users-and-roles.md)).
 

--- a/docs/administration/invitations-and-registration.md
+++ b/docs/administration/invitations-and-registration.md
@@ -19,7 +19,7 @@ To skip the wizard (e.g. when provisioning via automation and you'll create user
 
 ```yaml
 environment:
-  - DISABLE_SETUP_WIZARD=true
+    - DISABLE_SETUP_WIZARD=true
 ```
 
 You'll then need to create the first admin via the API or by injecting a database row at deploy time, because the UI won't offer a setup flow.

--- a/docs/administration/observability.md
+++ b/docs/administration/observability.md
@@ -16,9 +16,9 @@ It's often handy to know what's happening under the hood, especially when debugg
 
 ```yaml
 environment:
-  - LOGLEVEL=INFO # DEBUG | INFO | WARNING | ERROR
-  - FORCE_COLOR=0 # 1 to force colour even when not a TTY
-  - NO_COLOR=1 # 1 to disable colour entirely
+    - LOGLEVEL=INFO # DEBUG | INFO | WARNING | ERROR
+    - FORCE_COLOR=0 # 1 to force colour even when not a TTY
+    - NO_COLOR=1 # 1 to disable colour entirely
 ```
 
 `INFO` is the default and the sane choice for production. Drop to `DEBUG` only while debugging a specific issue, because `DEBUG` is chatty.
@@ -49,7 +49,7 @@ To turn it off for everyone (admins included), set:
 
 ```yaml
 environment:
-  - DISABLE_LOGS_VIEWER=true
+    - DISABLE_LOGS_VIEWER=true
 ```
 
 This also disables the `GET /api/logs` endpoint that backs it. The container logs above are unaffected.
@@ -85,7 +85,7 @@ Opt-in error tracking:
 
 ```yaml
 environment:
-  - SENTRY_DSN=https://abc123@sentry.example.com/42
+    - SENTRY_DSN=https://abc123@sentry.example.com/42
 ```
 
 What's sent:
@@ -102,10 +102,10 @@ If you're already using OpenTelemetry with your other apps and want unified obse
 
 ```yaml
 environment:
-  - OTEL_ENABLED=true
-  - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-  - OTEL_SERVICE_NAME=romm
-  - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod
+    - OTEL_ENABLED=true
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+    - OTEL_SERVICE_NAME=romm
+    - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod
 ```
 
 Standard [OTEL env vars](https://opentelemetry.io/docs/specs/otel/protocol/exporter/) apply. The app emits:

--- a/docs/administration/observability.md
+++ b/docs/administration/observability.md
@@ -16,9 +16,9 @@ It's often handy to know what's happening under the hood, especially when debugg
 
 ```yaml
 environment:
-    - LOGLEVEL=INFO # DEBUG | INFO | WARNING | ERROR
-    - FORCE_COLOR=0 # 1 to force colour even when not a TTY
-    - NO_COLOR=1 # 1 to disable colour entirely
+  - LOGLEVEL=INFO # DEBUG | INFO | WARNING | ERROR
+  - FORCE_COLOR=0 # 1 to force colour even when not a TTY
+  - NO_COLOR=1 # 1 to disable colour entirely
 ```
 
 `INFO` is the default and the sane choice for production. Drop to `DEBUG` only while debugging a specific issue, because `DEBUG` is chatty.
@@ -40,6 +40,19 @@ docker logs romm 2>&1 | grep ERROR
 docker logs romm 2>&1 | grep -iE 'auth|oidc|oauth'
 docker logs romm 2>&1 | grep -iE 'scan_handler.*Identified'
 ```
+
+### In-app logs viewer
+
+RomM also tails the server log live in the UI, with a filter by module (scan handler, auth, config manager, etc.), so you can watch a scan or debug an auth issue without shelling into the container. Access is gated on the `logs.read` scope.
+
+To turn it off for everyone (admins included), set:
+
+```yaml
+environment:
+  - DISABLE_LOGS_VIEWER=true
+```
+
+This also disables the `GET /api/logs` endpoint that backs it. The container logs above are unaffected.
 
 ## `/api/heartbeat`
 
@@ -72,7 +85,7 @@ Opt-in error tracking:
 
 ```yaml
 environment:
-    - SENTRY_DSN=https://abc123@sentry.example.com/42
+  - SENTRY_DSN=https://abc123@sentry.example.com/42
 ```
 
 What's sent:
@@ -89,10 +102,10 @@ If you're already using OpenTelemetry with your other apps and want unified obse
 
 ```yaml
 environment:
-    - OTEL_ENABLED=true
-    - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-    - OTEL_SERVICE_NAME=romm
-    - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod
+  - OTEL_ENABLED=true
+  - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+  - OTEL_SERVICE_NAME=romm
+  - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=prod
 ```
 
 Standard [OTEL env vars](https://opentelemetry.io/docs/specs/otel/protocol/exporter/) apply. The app emits:

--- a/docs/administration/oidc/index.md
+++ b/docs/administration/oidc/index.md
@@ -38,13 +38,13 @@ Whichever provider you pick, set these in the `romm` service's environment:
 
 ```yaml
 environment:
-  - OIDC_ENABLED=true
-  - OIDC_PROVIDER=<authelia|authentik|keycloak|pocket-id|zitadel|voidauth|generic>
-  - OIDC_CLIENT_ID=<from your provider>
-  - OIDC_CLIENT_SECRET=<from your provider>
-  - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
-  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
-  - ROMM_BASE_URL=https://demo.romm.app # must match your reverse-proxy URL
+    - OIDC_ENABLED=true
+    - OIDC_PROVIDER=<authelia|authentik|keycloak|pocket-id|zitadel|voidauth|generic>
+    - OIDC_CLIENT_ID=<from your provider>
+    - OIDC_CLIENT_SECRET=<from your provider>
+    - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
+    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+    - ROMM_BASE_URL=https://demo.romm.app # must match your reverse-proxy URL
 ```
 
 `OIDC_REDIRECT_URI` must exactly match what you register at the provider (same scheme, host, path, no trailing slash).
@@ -55,7 +55,7 @@ By default, the first successful OIDC login for an email that has no matching ac
 
 ```yaml
 environment:
-  - OIDC_ALLOW_REGISTRATION=false # default: true
+    - OIDC_ALLOW_REGISTRATION=false # default: true
 ```
 
 With it disabled, an unknown user is rejected at login instead of getting a fresh account. New accounts land in the [default permission group](../users-and-roles.md#permission-groups) unless a role claim maps them to Admin.
@@ -66,8 +66,8 @@ As of 5.0, RomM has only two roles: **User** and **Admin** (see [Users & Roles](
 
 ```yaml
 environment:
-  - OIDC_CLAIM_ROLES=groups # which claim to read
-  - OIDC_ROLE_ADMIN=romm-admin,platform-admins # group values → Admin
+    - OIDC_CLAIM_ROLES=groups # which claim to read
+    - OIDC_ROLE_ADMIN=romm-admin,platform-admins # group values → Admin
 ```
 
 On every login, the claim named by `OIDC_CLAIM_ROLES` is read (often `groups`, sometimes `realm_access.roles` on Keycloak, check your provider's token output). If a value matches `OIDC_ROLE_ADMIN`, the user becomes an Admin; otherwise they're a User in the default permission group.
@@ -84,7 +84,7 @@ To bypass the login page entirely and redirect straight to the IdP:
 
 ```yaml
 environment:
-  - OIDC_AUTOLOGIN=true
+    - OIDC_AUTOLOGIN=true
 ```
 
 Useful when you want this to feel like a native part of your SSO stack. Combine with `DISABLE_USERPASS_LOGIN=true` to lock out local accounts entirely.
@@ -99,8 +99,8 @@ When set, hitting "Sign out" in RomM also signs the user out at the IdP:
 
 ```yaml
 environment:
-  - OIDC_RP_INITIATED_LOGOUT=true
-  - OIDC_END_SESSION_ENDPOINT=https://auth.example.com/application/o/end-session/
+    - OIDC_RP_INITIATED_LOGOUT=true
+    - OIDC_END_SESSION_ENDPOINT=https://auth.example.com/application/o/end-session/
 ```
 
 The endpoint URL is provider-specific, check the per-provider guides or your IdP's docs.
@@ -111,7 +111,7 @@ By default the local part of the email (the bit before `@`) becomes the username
 
 ```yaml
 environment:
-  - OIDC_USERNAME_ATTRIBUTE=preferred_username
+    - OIDC_USERNAME_ATTRIBUTE=preferred_username
 ```
 
 ## Important notes

--- a/docs/administration/oidc/index.md
+++ b/docs/administration/oidc/index.md
@@ -17,7 +17,7 @@ OpenID Connect (OIDC) lets users sign in through an external identity provider: 
 2. They're redirected to your provider.
 3. They authenticate (password, passkey, MFA, whatever your provider enforces).
 4. Provider redirects back to `{ROMM_BASE_URL}/api/oauth/openid` with an authorisation code.
-5. The code is exchanged for an ID token, the user's email and role claims are read, and either a matching local user is created on the fly (unless you've turned off registration, see [Auto-provisioning](#auto-provisioning)) or an existing one is logged in.
+5. The code is exchanged for an ID token, the user's email and role claims are read, and either a matching local user is created on the fly (unless you've [turned off registration](#auto-provisioning)), or an existing one is logged in.
 
 ## Provider guides
 
@@ -62,7 +62,7 @@ With it disabled, an unknown user is rejected at login instead of getting a fres
 
 ## Role mapping
 
-As of 5.0, RomM has only two roles: **User** and **Admin** (see [Users & Roles](../users-and-roles.md#roles)). New OIDC users are provisioned as **Users**. To let your IdP promote someone to **Admin** based on group membership, set:
+RomM has only two roles: **User** and **Admin** (see [Users & Roles](../users-and-roles.md#roles)). New OIDC users are provisioned as **Users**. To let your IdP promote someone to **Admin** based on group membership, set:
 
 ```yaml
 environment:
@@ -76,7 +76,7 @@ Roles are re-evaluated on **every login**, so demoting someone on the IdP side t
 
 <!-- prettier-ignore -->
 !!! note "Legacy role variables"
-    `OIDC_ROLE_VIEWER` and `OIDC_ROLE_EDITOR` still exist for backwards compatibility but no longer map to distinct roles: matching users resolve to **User**. Use permission groups for finer-grained access. Only `OIDC_ROLE_ADMIN` still changes the role.
+    `OIDC_ROLE_VIEWER` and `OIDC_ROLE_EDITOR` still exist for backwards compatibility but no longer map to distinct roles. Matching users now resolve to **User**. Use permission groups for finer-grained access, as only `OIDC_ROLE_ADMIN` still changes the role.
 
 ## Autologin
 

--- a/docs/administration/oidc/index.md
+++ b/docs/administration/oidc/index.md
@@ -17,7 +17,7 @@ OpenID Connect (OIDC) lets users sign in through an external identity provider: 
 2. They're redirected to your provider.
 3. They authenticate (password, passkey, MFA, whatever your provider enforces).
 4. Provider redirects back to `{ROMM_BASE_URL}/api/oauth/openid` with an authorisation code.
-5. The code is exchanged for an ID token, the user's email and role claims are read, and either a matching local user is created on the fly or an existing one is logged in.
+5. The code is exchanged for an ID token, the user's email and role claims are read, and either a matching local user is created on the fly (unless you've turned off registration, see [Auto-provisioning](#auto-provisioning)) or an existing one is logged in.
 
 ## Provider guides
 
@@ -38,32 +38,45 @@ Whichever provider you pick, set these in the `romm` service's environment:
 
 ```yaml
 environment:
-    - OIDC_ENABLED=true
-    - OIDC_PROVIDER=<authelia|authentik|keycloak|pocket-id|zitadel|voidauth|generic>
-    - OIDC_CLIENT_ID=<from your provider>
-    - OIDC_CLIENT_SECRET=<from your provider>
-    - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
-    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
-    - ROMM_BASE_URL=https://demo.romm.app # must match your reverse-proxy URL
+  - OIDC_ENABLED=true
+  - OIDC_PROVIDER=<authelia|authentik|keycloak|pocket-id|zitadel|voidauth|generic>
+  - OIDC_CLIENT_ID=<from your provider>
+  - OIDC_CLIENT_SECRET=<from your provider>
+  - OIDC_SERVER_APPLICATION_URL=https://auth.example.com
+  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+  - ROMM_BASE_URL=https://demo.romm.app # must match your reverse-proxy URL
 ```
 
 `OIDC_REDIRECT_URI` must exactly match what you register at the provider (same scheme, host, path, no trailing slash).
 
-## Role mapping
+## Auto-provisioning
 
-By default, new OIDC users are provisioned as **Viewers**. To let your IdP assign roles based on group membership, set:
+By default, the first successful OIDC login for an email that has no matching account **creates** a local account automatically. To require accounts to exist beforehand (so only pre-provisioned users can sign in via OIDC), turn registration off:
 
 ```yaml
 environment:
-    - OIDC_CLAIM_ROLES=groups # which claim to read
-    - OIDC_ROLE_VIEWER=romm-viewer,guests # group names → Viewer
-    - OIDC_ROLE_EDITOR=romm-editor
-    - OIDC_ROLE_ADMIN=romm-admin,platform-admins
+  - OIDC_ALLOW_REGISTRATION=false # default: true
 ```
 
-On every login, the claim named by `OIDC_CLAIM_ROLES` is read (often `groups`, sometimes `realm_access.roles` on Keycloak, check your provider's token output). Whichever role has a matching value wins. If nothing matches, the user stays/becomes a Viewer.
+With it disabled, an unknown user is rejected at login instead of getting a fresh account. New accounts land in the [default permission group](../users-and-roles.md#permission-groups) unless a role claim maps them to Admin.
+
+## Role mapping
+
+As of 5.0, RomM has only two roles: **User** and **Admin** (see [Users & Roles](../users-and-roles.md#roles)). New OIDC users are provisioned as **Users**. To let your IdP promote someone to **Admin** based on group membership, set:
+
+```yaml
+environment:
+  - OIDC_CLAIM_ROLES=groups # which claim to read
+  - OIDC_ROLE_ADMIN=romm-admin,platform-admins # group values → Admin
+```
+
+On every login, the claim named by `OIDC_CLAIM_ROLES` is read (often `groups`, sometimes `realm_access.roles` on Keycloak, check your provider's token output). If a value matches `OIDC_ROLE_ADMIN`, the user becomes an Admin; otherwise they're a User in the default permission group.
 
 Roles are re-evaluated on **every login**, so demoting someone on the IdP side takes effect the next time they sign in.
+
+<!-- prettier-ignore -->
+!!! note "Legacy role variables"
+    `OIDC_ROLE_VIEWER` and `OIDC_ROLE_EDITOR` still exist for backwards compatibility but no longer map to distinct roles: matching users resolve to **User**. Use permission groups for finer-grained access. Only `OIDC_ROLE_ADMIN` still changes the role.
 
 ## Autologin
 
@@ -71,7 +84,7 @@ To bypass the login page entirely and redirect straight to the IdP:
 
 ```yaml
 environment:
-    - OIDC_AUTOLOGIN=true
+  - OIDC_AUTOLOGIN=true
 ```
 
 Useful when you want this to feel like a native part of your SSO stack. Combine with `DISABLE_USERPASS_LOGIN=true` to lock out local accounts entirely.
@@ -86,8 +99,8 @@ When set, hitting "Sign out" in RomM also signs the user out at the IdP:
 
 ```yaml
 environment:
-    - OIDC_RP_INITIATED_LOGOUT=true
-    - OIDC_END_SESSION_ENDPOINT=https://auth.example.com/application/o/end-session/
+  - OIDC_RP_INITIATED_LOGOUT=true
+  - OIDC_END_SESSION_ENDPOINT=https://auth.example.com/application/o/end-session/
 ```
 
 The endpoint URL is provider-specific, check the per-provider guides or your IdP's docs.
@@ -98,7 +111,7 @@ By default the local part of the email (the bit before `@`) becomes the username
 
 ```yaml
 environment:
-    - OIDC_USERNAME_ATTRIBUTE=preferred_username
+  - OIDC_USERNAME_ATTRIBUTE=preferred_username
 ```
 
 ## Important notes
@@ -112,4 +125,4 @@ environment:
 Common failures and fixes live in [Authentication Troubleshooting](../../troubleshooting/authentication.md). Two of the usual suspects:
 
 - `redirect_uri_mismatch`: `OIDC_REDIRECT_URI` differs from what's registered at the provider. Even a trailing slash can matter!
-- User created but stuck at Viewer: check `OIDC_CLAIM_ROLES` points at a claim that actually exists in the token, and the group names match exactly (case-sensitive).
+- User created but not made Admin: check `OIDC_CLAIM_ROLES` points at a claim that actually exists in the token, and that the group values match `OIDC_ROLE_ADMIN` exactly (case-sensitive).

--- a/docs/administration/oidc/keycloak.md
+++ b/docs/administration/oidc/keycloak.md
@@ -55,7 +55,7 @@ On the Keycloak side, go to **Admin Console → Users** and mark each user's ema
 
 Restart, navigate to `/login` and click the **Login with OIDC** button. You're redirected to Keycloak → authenticate → bounced back and signed in!
 
-If a local user already exists with a matching email, they're signed into that account. Otherwise a new account is created as a regular User in the default permission group (unless you've set `OIDC_ALLOW_REGISTRATION=false`, in which case unknown users are rejected).
+If a local user already exists with a matching email, they're signed into that account. Otherwise a new account is created as a regular User in the default permission group.
 
 If it doesn't work, head to [Authentication Troubleshooting](../../troubleshooting/authentication.md).
 
@@ -82,6 +82,6 @@ environment:
     - OIDC_ROLE_ADMIN=romm-admin
 ```
 
-Configure Keycloak's client to include the role/group claim in the ID token (usually via a **Group Membership** or **Realm Role** client scope mapper). Values in the claim are compared against `OIDC_ROLE_ADMIN` on every login, so demoting in Keycloak takes effect on the user's next sign-in. (`OIDC_ROLE_VIEWER` and `OIDC_ROLE_EDITOR` are legacy no-ops now that roles are just User and Admin.)
+Configure Keycloak's client to include the role/group claim in the ID token (usually via a **Group Membership** or **Realm Role** client scope mapper). Values in the claim are compared against `OIDC_ROLE_ADMIN` on every login, so demoting in Keycloak takes effect on the user's next sign-in.
 
 See [OIDC Setup → Role mapping](index.md#role-mapping) for the generic version.

--- a/docs/administration/oidc/keycloak.md
+++ b/docs/administration/oidc/keycloak.md
@@ -21,26 +21,26 @@ In the Admin Console, select your realm → **Clients** → **Create client**.
 2. **Client ID**: `romm` (or something unique).
 3. Click **Next**.
 4. On the capability page:
-    - Enable **Client authentication**
-    - Leave only **Standard flow** enabled
-    - Click **Next**
+   - Enable **Client authentication**
+   - Leave only **Standard flow** enabled
+   - Click **Next**
 5. Set URLs:
-    - **Root URL**: `https://demo.romm.app`
-    - **Valid Redirect URIs**: `https://demo.romm.app/api/oauth/openid`
-    - **Web origins**: `https://demo.romm.app`
+   - **Root URL**: `https://demo.romm.app`
+   - **Valid Redirect URIs**: `https://demo.romm.app/api/oauth/openid`
+   - **Web origins**: `https://demo.romm.app`
 6. Save, then head to the **Credentials** tab and copy the **Client Secret**.
 
 ## 3. Configure
 
 ```yaml
 environment:
-    - OIDC_ENABLED=true
-    - OIDC_PROVIDER=keycloak
-    - OIDC_CLIENT_ID=romm
-    - OIDC_CLIENT_SECRET=<from Keycloak Credentials tab>
-    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
-    - OIDC_SERVER_APPLICATION_URL=https://keycloak.example.com/realms/<realm-name>
-    - ROMM_BASE_URL=https://demo.romm.app
+  - OIDC_ENABLED=true
+  - OIDC_PROVIDER=keycloak
+  - OIDC_CLIENT_ID=romm
+  - OIDC_CLIENT_SECRET=<from Keycloak Credentials tab>
+  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+  - OIDC_SERVER_APPLICATION_URL=https://keycloak.example.com/realms/<realm-name>
+  - ROMM_BASE_URL=https://demo.romm.app
 ```
 
 `OIDC_SERVER_APPLICATION_URL` must include the realm (`.../realms/<realm-name>`), not just the Keycloak root.
@@ -55,7 +55,7 @@ On the Keycloak side, go to **Admin Console → Users** and mark each user's ema
 
 Restart, navigate to `/login` and click the **Login with OIDC** button. You're redirected to Keycloak → authenticate → bounced back and signed in!
 
-If a local user already exists with a matching email, they're signed into that account. Otherwise a new account is created with Viewer permissions.
+If a local user already exists with a matching email, they're signed into that account. Otherwise a new account is created as a regular User in the default permission group (unless you've set `OIDC_ALLOW_REGISTRATION=false`, in which case unknown users are rejected).
 
 If it doesn't work, head to [Authentication Troubleshooting](../../troubleshooting/authentication.md).
 
@@ -65,7 +65,7 @@ Force users through Keycloak:
 
 ```yaml
 environment:
-    - DISABLE_USERPASS_LOGIN=true
+  - DISABLE_USERPASS_LOGIN=true
 ```
 
 <!-- prettier-ignore -->
@@ -74,16 +74,14 @@ environment:
 
 ## 7. (Optional) Role mapping
 
-By default, new OIDC users come in as Viewers. To map Keycloak roles/groups to local roles:
+By default, new OIDC users come in as regular Users. To let Keycloak promote someone to **Admin** based on a role/group:
 
 ```yaml
 environment:
-    - OIDC_CLAIM_ROLES=groups # or realm_access.roles, depending on your token
-    - OIDC_ROLE_VIEWER=romm-viewer
-    - OIDC_ROLE_EDITOR=romm-editor
-    - OIDC_ROLE_ADMIN=romm-admin
+  - OIDC_CLAIM_ROLES=groups # or realm_access.roles, depending on your token
+  - OIDC_ROLE_ADMIN=romm-admin
 ```
 
-Configure Keycloak's client to include the role/group claim in the ID token (usually via a **Group Membership** or **Realm Role** client scope mapper). Values in the claim are compared against the `OIDC_ROLE_*` env vars on every login, so demoting in Keycloak takes effect on the user's next sign-in.
+Configure Keycloak's client to include the role/group claim in the ID token (usually via a **Group Membership** or **Realm Role** client scope mapper). Values in the claim are compared against `OIDC_ROLE_ADMIN` on every login, so demoting in Keycloak takes effect on the user's next sign-in. (`OIDC_ROLE_VIEWER` and `OIDC_ROLE_EDITOR` are legacy no-ops now that roles are just User and Admin.)
 
 See [OIDC Setup → Role mapping](index.md#role-mapping) for the generic version.

--- a/docs/administration/oidc/keycloak.md
+++ b/docs/administration/oidc/keycloak.md
@@ -21,26 +21,26 @@ In the Admin Console, select your realm → **Clients** → **Create client**.
 2. **Client ID**: `romm` (or something unique).
 3. Click **Next**.
 4. On the capability page:
-   - Enable **Client authentication**
-   - Leave only **Standard flow** enabled
-   - Click **Next**
+    - Enable **Client authentication**
+    - Leave only **Standard flow** enabled
+    - Click **Next**
 5. Set URLs:
-   - **Root URL**: `https://demo.romm.app`
-   - **Valid Redirect URIs**: `https://demo.romm.app/api/oauth/openid`
-   - **Web origins**: `https://demo.romm.app`
+    - **Root URL**: `https://demo.romm.app`
+    - **Valid Redirect URIs**: `https://demo.romm.app/api/oauth/openid`
+    - **Web origins**: `https://demo.romm.app`
 6. Save, then head to the **Credentials** tab and copy the **Client Secret**.
 
 ## 3. Configure
 
 ```yaml
 environment:
-  - OIDC_ENABLED=true
-  - OIDC_PROVIDER=keycloak
-  - OIDC_CLIENT_ID=romm
-  - OIDC_CLIENT_SECRET=<from Keycloak Credentials tab>
-  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
-  - OIDC_SERVER_APPLICATION_URL=https://keycloak.example.com/realms/<realm-name>
-  - ROMM_BASE_URL=https://demo.romm.app
+    - OIDC_ENABLED=true
+    - OIDC_PROVIDER=keycloak
+    - OIDC_CLIENT_ID=romm
+    - OIDC_CLIENT_SECRET=<from Keycloak Credentials tab>
+    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+    - OIDC_SERVER_APPLICATION_URL=https://keycloak.example.com/realms/<realm-name>
+    - ROMM_BASE_URL=https://demo.romm.app
 ```
 
 `OIDC_SERVER_APPLICATION_URL` must include the realm (`.../realms/<realm-name>`), not just the Keycloak root.
@@ -65,7 +65,7 @@ Force users through Keycloak:
 
 ```yaml
 environment:
-  - DISABLE_USERPASS_LOGIN=true
+    - DISABLE_USERPASS_LOGIN=true
 ```
 
 <!-- prettier-ignore -->
@@ -78,8 +78,8 @@ By default, new OIDC users come in as regular Users. To let Keycloak promote som
 
 ```yaml
 environment:
-  - OIDC_CLAIM_ROLES=groups # or realm_access.roles, depending on your token
-  - OIDC_ROLE_ADMIN=romm-admin
+    - OIDC_CLAIM_ROLES=groups # or realm_access.roles, depending on your token
+    - OIDC_ROLE_ADMIN=romm-admin
 ```
 
 Configure Keycloak's client to include the role/group claim in the ID token (usually via a **Group Membership** or **Realm Role** client scope mapper). Values in the claim are compared against `OIDC_ROLE_ADMIN` on every login, so demoting in Keycloak takes effect on the user's next sign-in. (`OIDC_ROLE_VIEWER` and `OIDC_ROLE_EDITOR` are legacy no-ops now that roles are just User and Admin.)

--- a/docs/administration/oidc/zitadel.md
+++ b/docs/administration/oidc/zitadel.md
@@ -13,7 +13,7 @@ Zitadel installed and running via their [self-hosted deployment docs](https://zi
 
 ## 2. Create a project
 
-Create a new project (e.g. `RomM`). This holds the client and its auth settings. On the **General** tab, **Check authorization on Authentication** is recommended. If turned off, anyone who can register in Zitadel can sign into RomM (as a Viewer). Turn this on if Zitadel registration is open.
+Create a new project (e.g. `RomM`). This holds the client and its auth settings. On the **General** tab, **Check authorization on Authentication** is recommended. If turned off, anyone who can register in Zitadel can sign into RomM (as a regular User). Turn this on if Zitadel registration is open.
 
 ### 2.5 (Optional) Grant users to the project
 
@@ -46,13 +46,13 @@ Without this, RomM throws "Email is missing from token" on login. Open the appli
 
 ```yaml
 environment:
-    - OIDC_ENABLED=true
-    - OIDC_PROVIDER=zitadel
-    - OIDC_CLIENT_ID=<from Zitadel>
-    - OIDC_CLIENT_SECRET=<from Zitadel>
-    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
-    - OIDC_SERVER_APPLICATION_URL=https://zitadel.example.com
-    - ROMM_BASE_URL=https://demo.romm.app
+  - OIDC_ENABLED=true
+  - OIDC_PROVIDER=zitadel
+  - OIDC_CLIENT_ID=<from Zitadel>
+  - OIDC_CLIENT_SECRET=<from Zitadel>
+  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+  - OIDC_SERVER_APPLICATION_URL=https://zitadel.example.com
+  - ROMM_BASE_URL=https://demo.romm.app
 ```
 
 Zitadel's OIDC discovery URL is at `<OIDC_SERVER_APPLICATION_URL>/.well-known/openid-configuration`, which is handy for debugging.

--- a/docs/administration/oidc/zitadel.md
+++ b/docs/administration/oidc/zitadel.md
@@ -46,13 +46,13 @@ Without this, RomM throws "Email is missing from token" on login. Open the appli
 
 ```yaml
 environment:
-  - OIDC_ENABLED=true
-  - OIDC_PROVIDER=zitadel
-  - OIDC_CLIENT_ID=<from Zitadel>
-  - OIDC_CLIENT_SECRET=<from Zitadel>
-  - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
-  - OIDC_SERVER_APPLICATION_URL=https://zitadel.example.com
-  - ROMM_BASE_URL=https://demo.romm.app
+    - OIDC_ENABLED=true
+    - OIDC_PROVIDER=zitadel
+    - OIDC_CLIENT_ID=<from Zitadel>
+    - OIDC_CLIENT_SECRET=<from Zitadel>
+    - OIDC_REDIRECT_URI=https://demo.romm.app/api/oauth/openid
+    - OIDC_SERVER_APPLICATION_URL=https://zitadel.example.com
+    - ROMM_BASE_URL=https://demo.romm.app
 ```
 
 Zitadel's OIDC discovery URL is at `<OIDC_SERVER_APPLICATION_URL>/.well-known/openid-configuration`, which is handy for debugging.

--- a/docs/administration/users-and-roles.md
+++ b/docs/administration/users-and-roles.md
@@ -5,26 +5,20 @@ description: User management, roles, and the permission-group model
 
 # Users & Roles
 
-RomM is multi-user from the start. The first user created during Setup is always an **Admin**, and everyone after that is a regular **User** whose access is governed by the [permission group](#permission-groups) you assign.
+The first user created during Setup is always an **Admin**, and everyone after that is a regular **User** whose access is governed by the [permission group](#permission-groups) you assign.
 
 ## Roles
 
 There are only two roles:
 
-| Role      | Who it's for                                    | Access                                                                                                        |
-| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Admin** | You, and anyone you fully trust.                | Everything. Admins **bypass permission groups** entirely, including user management and tasks.                |
-| **User**  | Everyone else: household members, guests, kids. | Whatever their assigned permission group grants, plus any per-user overrides. Nothing by default beyond that. |
-
-<!-- prettier-ignore -->
-!!! note "Upgrading from a pre-5.0 instance"
-    Earlier versions had three roles: **Viewer**, **Editor**, and **Admin**. In 5.0 these collapse to **User** and **Admin**. Existing Viewer and Editor accounts become **Users** and are placed in an auto-created **system** permission group that reproduces their old level of access, so nobody loses (or gains) permissions on upgrade. System groups are flagged in the UI, which warns before you edit or delete one.
+| Role      | Who it's for                     | Access                                                                             |
+| --------- | -------------------------------- | ---------------------------------------------------------------------------------- |
+| **Admin** | You, and anyone you fully trust. | Admins **bypass permission groups** entirely, including user management and tasks. |
+| **User**  | Everyone else                    | Whatever their assigned permission group grants, plus any per-user overrides.      |
 
 ## Permission groups
 
-Fine-grained access is no longer baked into the role. Instead, each User belongs to a **permission group**: a named template of capabilities that you manage in the new UI (**Administration → Permissions**). Admins ignore groups completely.
-
-A group is a **grant matrix** over entity types and actions:
+Each User belongs to a **permission group**: a named template of capabilities that you manage in the new UI (**Administration → Permissions**). A group is a **grant matrix** over entity types and actions:
 
 | Entity        | `read`                        | `write`                          | `delete`         |
 | ------------- | ----------------------------- | -------------------------------- | ---------------- |
@@ -41,29 +35,28 @@ A group is a **grant matrix** over entity types and actions:
 Rules of the model:
 
 - **A missing grant means denied.** A group only allows what it explicitly lists.
-- **`own_only`** narrows a grant to entities the user owns. For example, `assets` `write` with `own_only` lets a user manage their own saves/states/screenshots but not anyone else's.
-- **Default group** (`is_default`): exactly one group is marked as the server-wide default and is applied automatically to every new User (invite sign-up, OIDC first login, admin-created accounts without an explicit group).
+- **`own_only`** narrows a grant to entities the user owns. For example, `assets.write` with `own_only` lets a user manage their own saves/states/screenshots but not anyone else's.
+- **Default group**: exactly one group is marked as the server-wide default and is applied automatically to every new User (invite sign-up, OIDC first login, admin-created accounts without an explicit group).
 
 ### Per-user overrides
 
-On top of the group, you can **add or revoke a single capability** for one user without creating a whole new group:
+On top of the group, you can **add or revoke individual capabilities** for one user without creating a whole new group:
 
 - **Grant** an override to give a user something their group lacks.
 - **Revoke** an override to take away something their group provides.
-- With no override for a given `(entity, action)`, the user's group decides.
 
-Use overrides for one-offs ("this one user can also delete ROMs"); use groups for anything you'd apply to more than one person.
+Use overrides for one-offs ("this one user can also delete ROMs"), and use groups for anything you'd apply to more than one person.
 
 ### Hidden entities
 
-Beyond allow/deny, you can **hide specific platforms or ROMs** from a user or from an entire group. A hidden entity simply doesn't appear for that principal, regardless of read grants. Firmware visibility isn't hidden directly, it cascades from the platform it belongs to.
+Beyond allow/deny, you can **hide specific platforms or ROMs** from a user or from an entire group. A hidden entity simply doesn't appear for that principal, regardless of read grants. Firmware visibility isn't hidden directly, as it cascades from the platform it belongs to.
 
 ## Creating users
 
 Three paths:
 
-- **Admin adds directly**: set username, email, password, role, and (for Users) a permission group. The account is usable immediately.
-- **Invite link**: better when you don't want to handle someone else's password. The admin generates a single-use link, and the recipient picks their own credentials. New Users land in the default permission group. Invite links expire after 600 seconds by default, configurable via [`INVITE_TOKEN_EXPIRY_SECONDS`](../reference/environment-variables.md).
+- **Admin page**: set username, email, password, role, and a permission group. The account is usable immediately.
+- **Invite link**: when you don't want to handle someone else's password. The admin generates a single-use link, and the recipient picks their own credentials. New Users land in the default permission group. Invite links expire after 600 seconds by default, configurable via [`INVITE_TOKEN_EXPIRY_SECONDS`](../reference/environment-variables.md).
 - **OIDC**: if you've wired up OIDC, new identities can be provisioned on first login. Whether that happens is controlled by `OIDC_ALLOW_REGISTRATION`, and Admin mapping from OIDC claims is covered in [OIDC Setup](oidc/index.md).
 
 ## Editing and deleting users

--- a/docs/administration/users-and-roles.md
+++ b/docs/administration/users-and-roles.md
@@ -1,62 +1,96 @@
 ---
 title: Users & Roles
-description: User management, roles, and the scope model
+description: User management, roles, and the permission-group model
 ---
 
 # Users & Roles
 
-RomM is multi-user from the start. The first user created during Setup is always an **Admin**, and everyone after that gets the role you assign when creating the account.
+RomM is multi-user from the start. The first user created during Setup is always an **Admin**, and everyone after that is a regular **User** whose access is governed by the [permission group](#permission-groups) you assign.
 
 ## Roles
 
-| Role       | Who it's for                                                            | Default scopes                                                                    |
-| ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **Admin**  | You, and anyone you fully trust.                                        | All scopes, including user management and task execution.                         |
-| **Editor** | Household members who help curate the library.                          | Read everything, edit ROMs/platforms/collections, upload, but no user management. |
-| **Viewer** | Guests, kids, anyone who should only play and track their own progress. | Read the library, manage their own saves/states/screenshots/profile.              |
+There are only two roles:
 
-Roles are a convenience layer on top of **scopes** (see the scope matrix below for exactly what each role grants). You can't create custom roles (yet), so if you need finer-grained access, use the most restrictive role and rely on [Client API Tokens](../developers/client-api-tokens.md) for per-app customisation.
+| Role      | Who it's for                                    | Access                                                                                                        |
+| --------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Admin** | You, and anyone you fully trust.                | Everything. Admins **bypass permission groups** entirely, including user management and tasks.                |
+| **User**  | Everyone else: household members, guests, kids. | Whatever their assigned permission group grants, plus any per-user overrides. Nothing by default beyond that. |
 
-## Scope matrix
+<!-- prettier-ignore -->
+!!! note "Upgrading from a pre-5.0 instance"
+    Earlier versions had three roles: **Viewer**, **Editor**, and **Admin**. In 5.0 these collapse to **User** and **Admin**. Existing Viewer and Editor accounts become **Users** and are placed in an auto-created **system** permission group that reproduces their old level of access, so nobody loses (or gains) permissions on upgrade. System groups are flagged in the UI, which warns before you edit or delete one.
 
-RomM authorisation is scope-based. Every API call and UI action maps to one or more scopes, and OAuth tokens and OIDC sessions carry a subset of them. Nineteen scopes total, grouped by resource:
+## Permission groups
 
-| Scope               | Purpose                                         | Viewer | Editor | Admin |
-| ------------------- | ----------------------------------------------- | :----: | :----: | :---: |
-| `me.read`           | View own profile                                |   ✓    |   ✓    |   ✓   |
-| `me.write`          | Edit own profile                                |   ✓    |   ✓    |   ✓   |
-| `roms.read`         | Browse ROMs                                     |   ✓    |   ✓    |   ✓   |
-| `roms.user.read`    | View own per-ROM data (rating, playtime, notes) |   ✓    |   ✓    |   ✓   |
-| `roms.user.write`   | Edit own per-ROM data                           |   ✓    |   ✓    |   ✓   |
-| `platforms.read`    | Browse platforms                                |   ✓    |   ✓    |   ✓   |
-| `assets.read`       | View own saves/states/screenshots               |   ✓    |   ✓    |   ✓   |
-| `assets.write`      | Upload saves/states/screenshots                 |   ✓    |   ✓    |   ✓   |
-| `collections.read`  | Browse collections                              |   ✓    |   ✓    |   ✓   |
-| `collections.write` | Create/edit collections                         |   -    |   ✓    |   ✓   |
-| `roms.write`        | Edit ROM metadata                               |   -    |   ✓    |   ✓   |
-| `platforms.write`   | Edit/create platforms                           |   -    |   ✓    |   ✓   |
-| `firmware.read`     | List firmware                                   |   -    |   ✓    |   ✓   |
-| `firmware.write`    | Upload/delete firmware                          |   -    |   ✓    |   ✓   |
-| `devices.read`      | View own paired devices                         |   ✓    |   ✓    |   ✓   |
-| `devices.write`     | Manage own paired devices                       |   ✓    |   ✓    |   ✓   |
-| `users.read`        | List all users                                  |   -    |   -    |   ✓   |
-| `users.write`       | Create/edit/delete users                        |   -    |   -    |   ✓   |
-| `tasks.run`         | Trigger background tasks (scan, cleanup, etc.)  |   -    |   -    |   ✓   |
+Fine-grained access is no longer baked into the role. Instead, each User belongs to a **permission group**: a named template of capabilities that you manage in the new UI (**Administration → Permissions**). Admins ignore groups completely.
+
+A group is a **grant matrix** over entity types and actions:
+
+| Entity        | `read`                        | `write`                          | `delete`         |
+| ------------- | ----------------------------- | -------------------------------- | ---------------- |
+| `platforms`   | Browse platforms              | Edit/create platforms            | Delete platforms |
+| `roms`        | Browse ROMs                   | Edit ROM metadata                | Delete ROMs      |
+| `collections` | Browse collections            | Create/edit                      | Delete           |
+| `firmware`    | List firmware                 | Upload firmware                  | Delete firmware  |
+| `assets`      | View saves/states/screenshots | Upload/replace                   | Delete           |
+| `devices`     | View paired devices           | Pair/manage devices              | Unpair devices   |
+| `users`       | List users                    | Create/edit users                | Delete users     |
+| `tasks`       | View task status              | Trigger tasks (scan, cleanup, …) | —                |
+| `logs`        | View server logs              | —                                | —                |
+
+Rules of the model:
+
+- **A missing grant means denied.** A group only allows what it explicitly lists.
+- **`own_only`** narrows a grant to entities the user owns. For example, `assets` `write` with `own_only` lets a user manage their own saves/states/screenshots but not anyone else's.
+- **Default group** (`is_default`): exactly one group is marked as the server-wide default and is applied automatically to every new User (invite sign-up, OIDC first login, admin-created accounts without an explicit group).
+
+### Per-user overrides
+
+On top of the group, you can **add or revoke a single capability** for one user without creating a whole new group:
+
+- **Grant** an override to give a user something their group lacks.
+- **Revoke** an override to take away something their group provides.
+- With no override for a given `(entity, action)`, the user's group decides.
+
+Use overrides for one-offs ("this one user can also delete ROMs"); use groups for anything you'd apply to more than one person.
+
+### Hidden entities
+
+Beyond allow/deny, you can **hide specific platforms or ROMs** from a user or from an entire group. A hidden entity simply doesn't appear for that principal, regardless of read grants. Firmware visibility isn't hidden directly, it cascades from the platform it belongs to.
 
 ## Creating users
 
 Three paths:
 
-- **Admin adds directly**: set username, email, password, and role, and the account is usable immediately.
-- **Invite link**: better when you don't want to handle someone else's password. The admin generates a single-use link with a pre-assigned role, and the recipient picks their own credentials. Invite links expire after 600 seconds by default, configurable via [`INVITE_TOKEN_EXPIRY_SECONDS`](../reference/environment-variables.md).
-- **OIDC**: if you've wired up OIDC, new identities can be provisioned on first login. Role mapping from OIDC claims is covered in [OIDC Setup](oidc/index.md).
+- **Admin adds directly**: set username, email, password, role, and (for Users) a permission group. The account is usable immediately.
+- **Invite link**: better when you don't want to handle someone else's password. The admin generates a single-use link, and the recipient picks their own credentials. New Users land in the default permission group. Invite links expire after 600 seconds by default, configurable via [`INVITE_TOKEN_EXPIRY_SECONDS`](../reference/environment-variables.md).
+- **OIDC**: if you've wired up OIDC, new identities can be provisioned on first login. Whether that happens is controlled by `OIDC_ALLOW_REGISTRATION`, and Admin mapping from OIDC claims is covered in [OIDC Setup](oidc/index.md).
 
 ## Editing and deleting users
 
-Admins can change any user's role, reset their password, or delete the account. Role changes take effect on next login. You can't delete the last admin or delete yourself while signed in.
+Admins can change any user's role, move them between permission groups, add per-user overrides, reset their password, or delete the account. Role and permission changes take effect on next login. You can't delete the last admin or delete yourself while signed in.
 
 Deleting a user keeps their contributions (collections they made public, ROM metadata edits) but removes their personal data from the database (per-ROM ratings, saves, states, play sessions, paired devices, API tokens). It does not delete any files from disk.
 
+## OAuth scopes
+
+The permission groups above are the source of truth for the UI. For the **API**, RomM derives a flat set of OAuth **scopes** from a user's effective grants (group + overrides). Each `(entity, action)` grant maps to the scope of the same name, e.g. `roms` + `write` → `roms.write`. Client API Tokens and OIDC sessions carry a **subset** of the owning user's scopes, and every endpoint declares which scopes it requires.
+
+The full scope list (grouped by resource):
+
+| Resource    | Scopes                                                         |
+| ----------- | -------------------------------------------------------------- |
+| Profile     | `me.read`, `me.write`                                          |
+| ROMs        | `roms.read`, `roms.write`, `roms.user.read`, `roms.user.write` |
+| Platforms   | `platforms.read`, `platforms.write`                            |
+| Assets      | `assets.read`, `assets.write`                                  |
+| Collections | `collections.read`, `collections.write`                        |
+| Firmware    | `firmware.read`, `firmware.write`                              |
+| Devices     | `devices.read`, `devices.write`                                |
+| Users       | `users.read`, `users.write`                                    |
+| Tasks       | `tasks.run`                                                    |
+| Logs        | `logs.read`                                                    |
+
 ## API tokens (advanced)
 
-Each user can issue up to 25 **Client API Tokens**. Tokens carry a subset of the user's scopes and are the right way to authenticate companion apps (Argosy, Grout, Playnite, custom scripts). The pairing flow for devices is covered in [Client API Tokens](../developers/client-api-tokens.md), and the API side is in [API Authentication](../developers/api-authentication.md).
+Each user can issue up to 25 **Client API Tokens**. A token carries a subset of the owning user's scopes (see above), whichever you pick at creation time. Tokens are the right way to authenticate companion apps (Argosy, Grout, Playnite, custom scripts). The pairing flow for devices is covered in [Client API Tokens](../developers/client-api-tokens.md), and the API side is in [API Authentication](../developers/api-authentication.md).

--- a/docs/developers/api-authentication.md
+++ b/docs/developers/api-authentication.md
@@ -69,11 +69,11 @@ grant_type=password&username=alice&password=s3cret&scope=roms.read%20roms.write
 
 ```json
 {
-  "access_token": "eyJhbGciOi...",
-  "refresh_token": "eyJhbGciOi...",
-  "token_type": "bearer",
-  "expires": 1800,
-  "refresh_expires": 604800
+    "access_token": "eyJhbGciOi...",
+    "refresh_token": "eyJhbGciOi...",
+    "token_type": "bearer",
+    "expires": 1800,
+    "refresh_expires": 604800
 }
 ```
 

--- a/docs/developers/api-authentication.md
+++ b/docs/developers/api-authentication.md
@@ -14,7 +14,7 @@ The API accepts multiple authentication modes:
 | **OAuth2 Bearer**    | Automation, CI, third-party apps                         | `Authorization: Bearer <jwt>`                    |
 | **Client API Token** | Companion apps (Argosy, Grout, Playnite, custom scripts) | `Authorization: Bearer rmm_<token>`              |
 
-All of them resolve to the same scope model. See the [scope matrix in Users & Roles](../administration/users-and-roles.md#scope-matrix). A request is allowed if the active identity holds all scopes the endpoint requires.
+All of them resolve to the same scope model. See the [OAuth scopes in Users & Roles](../administration/users-and-roles.md#oauth-scopes). A request is allowed if the active identity holds all scopes the endpoint requires.
 
 ## Base URL
 
@@ -69,11 +69,11 @@ grant_type=password&username=alice&password=s3cret&scope=roms.read%20roms.write
 
 ```json
 {
-    "access_token": "eyJhbGciOi...",
-    "refresh_token": "eyJhbGciOi...",
-    "token_type": "bearer",
-    "expires": 1800,
-    "refresh_expires": 604800
+  "access_token": "eyJhbGciOi...",
+  "refresh_token": "eyJhbGciOi...",
+  "token_type": "bearer",
+  "expires": 1800,
+  "refresh_expires": 604800
 }
 ```
 

--- a/docs/developers/client-api-tokens.md
+++ b/docs/developers/client-api-tokens.md
@@ -82,11 +82,11 @@ The companion app stores the token and uses it on every subsequent API call. Fro
 
 ## Scoping tokens properly
 
-A token can only hold scopes the owning user _also_ holds. If the user is an Editor, their token can hold any Editor scope but not `users.write` (which is Admin-only). Default to read-only, and only grant write scopes the app actually needs.
+A token can only hold scopes the owning user _also_ holds, and a user's scopes come from their [permission group](../administration/users-and-roles.md#permission-groups) plus any overrides (Admins hold everything). For example, a token can't carry `users.write` unless its owner is an Admin. Default to read-only, and only grant write scopes the app actually needs.
 
-## What happens on user role change
+## What happens on permission change
 
-If the owning user's role drops below what the token needs, the token continues to exist but fails at request time with **403 Forbidden**. It's the user's decision to revoke it. However if the user is deleted, all their tokens are revoked immediately.
+If the owning user's permissions are narrowed so they no longer hold what a token needs, the token continues to exist but fails at request time with **403 Forbidden**. It's the user's decision to revoke it. However if the user is deleted, all their tokens are revoked immediately.
 
 ## Anti-patterns
 
@@ -99,4 +99,4 @@ If the owning user's role drops below what the token needs, the token continues 
 
 - [Device Sync Protocol](device-sync-protocol.md): how the synced content flows after pairing
 - [API Authentication](api-authentication.md): all RomM auth modes side-by-side
-- [Users & Roles → scope matrix](../administration/users-and-roles.md#scope-matrix): the 19-scope taxonomy
+- [Users & Roles → OAuth scopes](../administration/users-and-roles.md#oauth-scopes): the full scope taxonomy

--- a/docs/ecosystem/first-party-apps.md
+++ b/docs/ecosystem/first-party-apps.md
@@ -114,7 +114,7 @@ Open **Menu → Library → Configure Integrations → RomM** and enter:
 - **Host URL**, including the protocol and without a trailing slash, for example `https://romm.example.com`
 - Your **username** and **password**
 
-Passwords are stored in plaintext in Playnite, so use a separate account with the **VIEWER** role rather than your main credentials.
+Passwords are stored in plaintext in Playnite, so use a separate account with a **read-only permission group** rather than your main credentials.
 
 #### Map emulator paths
 

--- a/docs/reference/configuration-file.md
+++ b/docs/reference/configuration-file.md
@@ -28,7 +28,7 @@ Skip entire platform folders. Values are platform slugs, not folder names (see [
 
 ```yaml
 exclude:
-    platforms: ["ps", "ngc", "gba"]
+  platforms: ["ps", "ngc", "gba"]
 ```
 
 ### `exclude.roms.single_file.extensions`
@@ -39,9 +39,9 @@ Drop files with these extensions before matching, only for files that aren't ins
 
 ```yaml
 exclude:
-    roms:
-        single_file:
-            extensions: ["xml", "txt"]
+  roms:
+    single_file:
+      extensions: ["xml", "txt"]
 ```
 
 ### `exclude.roms.single_file.names`
@@ -52,9 +52,9 @@ Unix-glob file-name patterns to skip.
 
 ```yaml
 exclude:
-    roms:
-        single_file:
-            names: ["info.txt", "._*", "*.nfo"]
+  roms:
+    single_file:
+      names: ["info.txt", "._*", "*.nfo"]
 ```
 
 ### `exclude.roms.multi_file.names`
@@ -65,9 +65,9 @@ Skip whole folders. Used for multi-disc/multi-file games you want invisible.
 
 ```yaml
 exclude:
-    roms:
-        multi_file:
-            names: ["final fantasy VII", "DLC"]
+  roms:
+    multi_file:
+      names: ["final fantasy VII", "DLC"]
 ```
 
 ### `exclude.roms.multi_file.parts.names`
@@ -78,10 +78,10 @@ Files **inside** a multi-file ROM folder to ignore (e.g. `.nfo`, `._*` macOS att
 
 ```yaml
 exclude:
-    roms:
-        multi_file:
-            parts:
-                names: ["data.xml", "._*"]
+  roms:
+    multi_file:
+      parts:
+        names: ["data.xml", "._*"]
 ```
 
 ### `exclude.roms.multi_file.parts.extensions`
@@ -92,10 +92,10 @@ Extensions to ignore inside a multi-file ROM folder.
 
 ```yaml
 exclude:
-    roms:
-        multi_file:
-            parts:
-                extensions: ["xml", "txt"]
+  roms:
+    multi_file:
+      parts:
+        extensions: ["xml", "txt"]
 ```
 
 ---
@@ -110,10 +110,10 @@ Map your folder names to [supported platform](../platforms/supported-platforms.m
 
 ```yaml
 system:
-    platforms:
-        gc: "ngc" # treat "gc/" folder as GameCube
-        psx: "ps" # treat "psx/" folder as PlayStation
-        super_nintendo: "snes"
+  platforms:
+    gc: "ngc" # treat "gc/" folder as GameCube
+    psx: "ps" # treat "psx/" folder as PlayStation
+    super_nintendo: "snes"
 ```
 
 ### `system.versions`
@@ -122,8 +122,8 @@ Associate a platform with its "main" IGDB version, for platforms that have multi
 
 ```yaml
 system:
-    versions:
-        naomi: "arcade"
+  versions:
+    naomi: "arcade"
 ```
 
 ---
@@ -136,7 +136,7 @@ Override the default ROMs folder name (`roms`).
 
 ```yaml
 filesystem:
-    roms_folder: "my_roms"
+  roms_folder: "my_roms"
 ```
 
 ### `filesystem.firmware_folder`
@@ -145,7 +145,7 @@ Override the default BIOS/firmware folder name (`bios`).
 
 ```yaml
 filesystem:
-    firmware_folder: "firmware"
+  firmware_folder: "firmware"
 ```
 
 ### `filesystem.skip_hash_calculation`
@@ -156,7 +156,7 @@ Skip hashing on low-power devices. You lose hash-based matching (RetroAchievemen
 
 ```yaml
 filesystem:
-    skip_hash_calculation: true
+  skip_hash_calculation: true
 ```
 
 ---
@@ -171,11 +171,11 @@ Order metadata providers are queried during a scan. First match wins for descrip
 
 ```yaml
 scan:
-    priority:
-        metadata:
-            - "igdb"
-            - "ss"
-            - "moby"
+  priority:
+    metadata:
+      - "igdb"
+      - "ss"
+      - "moby"
 ```
 
 Values are the provider slugs. Full list:
@@ -202,11 +202,11 @@ Same idea, for cover art and screenshots. Defaults to the same order as `scan.pr
 
 ```yaml
 scan:
-    priority:
-        artwork:
-            - "ss" # prefer ScreenScraper artwork
-            - "igdb"
-            - "moby"
+  priority:
+    artwork:
+      - "ss" # prefer ScreenScraper artwork
+      - "igdb"
+      - "moby"
 ```
 
 ### `scan.priority.region`
@@ -217,11 +217,11 @@ Preferred region for titles, cover art, and regional variants. ScreenScraper use
 
 ```yaml
 scan:
-    priority:
-        region:
-            - "us"
-            - "eu"
-            - "jp"
+  priority:
+    region:
+      - "us"
+      - "eu"
+      - "jp"
 ```
 
 ### `scan.priority.language`
@@ -232,40 +232,43 @@ Preferred localisation language.
 
 ```yaml
 scan:
-    priority:
-        language:
-            - "en"
-            - "es"
-            - "fr"
+  priority:
+    language:
+      - "en"
+      - "es"
+      - "fr"
 ```
 
 ### `scan.media`
 
 Which media types to fetch during a scan, primarily for ScreenScraper and the gamelist.xml importer.
 
-| Type           | Description                                  |
-| -------------- | -------------------------------------------- |
-| `box2d`        | Normal 2D cover art. Always enabled.         |
-| `box2d_back`   | Back cover art.                              |
-| `box2d_side`   | 2D side/spine box art.                       |
-| `box3d`        | 3D box art.                                  |
-| `miximage`     | Composite image (box + screenshot + logo).   |
-| `physical`     | Physical media (disc, cartridge).            |
-| `screenshot`   | In-game screenshot. Enabled by default.      |
-| `title_screen` | Title-screen capture.                        |
-| `marquee`      | Transparent logo.                            |
-| `fanart`       | Community-uploaded fan art.                  |
-| `bezel`        | EmulatorJS-compatible bezel.                 |
-| `manual`       | PDF manual. Enabled by default.              |
-| `video`        | Gameplay video (big files, watch your disk). |
+| Type               | Description                                  |
+| ------------------ | -------------------------------------------- |
+| `box2d`            | Normal 2D cover art. Always enabled.         |
+| `box2d_back`       | Back cover art.                              |
+| `box2d_side`       | 2D side/spine box art.                       |
+| `box3d`            | 3D box art.                                  |
+| `miximage`         | Composite image (box + screenshot + logo).   |
+| `miximage_v2`      | Newer composite-image layout.                |
+| `physical`         | Physical media (disc, cartridge).            |
+| `screenshot`       | In-game screenshot. Enabled by default.      |
+| `title_screen`     | Title-screen capture.                        |
+| `marquee`          | Transparent logo.                            |
+| `logo`             | Clear/wheel logo art.                        |
+| `fanart`           | Community-uploaded fan art.                  |
+| `bezel`            | EmulatorJS-compatible bezel.                 |
+| `manual`           | PDF manual. Enabled by default.              |
+| `video`            | Gameplay video (big files, watch your disk). |
+| `video_normalized` | Loudness-normalised gameplay video.          |
 
 ```yaml
 scan:
-    media:
-        - box2d
-        - screenshot
-        - manual
-        - bezel
+  media:
+    - box2d
+    - screenshot
+    - manual
+    - bezel
 ```
 
 ### `scan.gamelist.export`
@@ -274,11 +277,11 @@ Generate a `gamelist.xml` in each platform folder, compatible with ES-DE/Batocer
 
 ```yaml
 scan:
-    gamelist:
-        export: true
-        media:
-            thumbnail: box2d
-            image: screenshot
+  gamelist:
+    export: true
+    media:
+      thumbnail: box2d
+      image: screenshot
 ```
 
 ### `scan.pegasus.export`
@@ -287,8 +290,8 @@ Export metadata in Pegasus-frontend format (`metadata.pegasus.txt`).
 
 ```yaml
 scan:
-    pegasus:
-        export: true
+  pegasus:
+    export: true
 ```
 
 ---
@@ -305,7 +308,7 @@ Log available EmulatorJS options to the browser console for debugging.
 
 ```yaml
 emulatorjs:
-    debug: true
+  debug: true
 ```
 
 ### `emulatorjs.cache_limit`
@@ -314,7 +317,7 @@ Per-ROM cache limit in bytes. `null` = unlimited.
 
 ```yaml
 emulatorjs:
-    cache_limit: 52428800 # 50 MB
+  cache_limit: 52428800 # 50 MB
 ```
 
 ### `emulatorjs.disable_batch_bootup`
@@ -323,7 +326,7 @@ DOS-specific knob that skips the `autorun.bat` step. Toggle if DOS games won't b
 
 ```yaml
 emulatorjs:
-    disable_batch_bootup: true
+  disable_batch_bootup: true
 ```
 
 ### `emulatorjs.disable_auto_unload`
@@ -332,7 +335,7 @@ By default, EmulatorJS stops the emulator when you leave its page. Disable to ke
 
 ```yaml
 emulatorjs:
-    disable_auto_unload: true
+  disable_auto_unload: true
 ```
 
 ### `emulatorjs.netplay`
@@ -341,18 +344,18 @@ Toggle Netplay and configure STUN/TURN servers. Google's public STUN servers are
 
 ```yaml
 emulatorjs:
-    netplay:
-        enabled: true
-        ice_servers:
-            - urls: "stun:stun.l.google.com:19302"
-            - urls: "stun:stun1.l.google.com:19302"
-            - urls: "stun:stun2.l.google.com:19302"
-            - urls: "turn:openrelay.metered.ca:80"
-              username: "openrelayproject"
-              credential: "openrelayproject"
-            - urls: "turn:openrelay.metered.ca:443"
-              username: "openrelayproject"
-              credential: "openrelayproject"
+  netplay:
+    enabled: true
+    ice_servers:
+      - urls: "stun:stun.l.google.com:19302"
+      - urls: "stun:stun1.l.google.com:19302"
+      - urls: "stun:stun2.l.google.com:19302"
+      - urls: "turn:openrelay.metered.ca:80"
+        username: "openrelayproject"
+        credential: "openrelayproject"
+      - urls: "turn:openrelay.metered.ca:443"
+        username: "openrelayproject"
+        credential: "openrelayproject"
 ```
 
 <!-- prettier-ignore -->
@@ -365,13 +368,13 @@ Per-core emulator options. Use `default` to apply to every core.
 
 ```yaml
 emulatorjs:
-    settings:
-        parallel_n64:
-            vsync: disable
-        snes9x:
-            snes9x_region: ntsc
-        default:
-            fps: show
+  settings:
+    parallel_n64:
+      vsync: disable
+    snes9x:
+      snes9x_region: ntsc
+    default:
+      fps: show
 ```
 
 Core names must match the EmulatorJS core identifier exactly. To discover core names and per-core option keys, turn on `debug: true`, load a game in that core, open the browser console, filter for "option", and copy the keys you care about. Upstream reference is available in [EmulatorJS core options](https://emulatorjs.org/docs4devs/settings/).
@@ -382,16 +385,16 @@ Map keyboard and controller buttons per core, per player.
 
 ```yaml
 emulatorjs:
-    controls:
-        snes9x:
-            0: # player 1
-                0: # button slot
-                    value: x # keyboard key
-                    value2: BUTTON_2 # controller button
-            1: # player 2
-                0:
-                    value: /
-                    value2: BUTTON_2
+  controls:
+    snes9x:
+      0: # player 1
+        0: # button slot
+          value: x # keyboard key
+          value2: BUTTON_2 # controller button
+      1: # player 2
+        0:
+          value: /
+          value2: BUTTON_2
 ```
 
 See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/control-mapping/) for the button-slot reference. Users can override these defaults in-game via Menu → **Controls**, the config.yml setting only sets the starting point.
@@ -400,19 +403,19 @@ See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/contr
 
 ```yaml
 emulatorjs:
-    settings:
-        snes9x:
-            snes9x_region: ntsc
-    controls:
-        snes9x:
-            0: # P1 on keyboard (WASD cluster)
-                0: { value: ",", value2: "BUTTON_2" } # B
-                1: { value: ".", value2: "BUTTON_3" } # A
-                2: { value: "l", value2: "BUTTON_1" } # Y
-                3: { value: "p", value2: "BUTTON_4" } # X
-            1: # P2 on arrows + numpad
-                0: { value: "/", value2: "BUTTON_2" }
-                1: { value: "'", value2: "BUTTON_3" }
+  settings:
+    snes9x:
+      snes9x_region: ntsc
+  controls:
+    snes9x:
+      0: # P1 on keyboard (WASD cluster)
+        0: { value: ",", value2: "BUTTON_2" } # B
+        1: { value: ".", value2: "BUTTON_3" } # A
+        2: { value: "l", value2: "BUTTON_1" } # Y
+        3: { value: "p", value2: "BUTTON_4" } # X
+      1: # P2 on arrows + numpad
+        0: { value: "/", value2: "BUTTON_2" }
+        1: { value: "'", value2: "BUTTON_3" }
 ```
 
 ### Operator-level vs per-user

--- a/docs/reference/configuration-file.md
+++ b/docs/reference/configuration-file.md
@@ -28,7 +28,7 @@ Skip entire platform folders. Values are platform slugs, not folder names (see [
 
 ```yaml
 exclude:
-  platforms: ["ps", "ngc", "gba"]
+    platforms: ["ps", "ngc", "gba"]
 ```
 
 ### `exclude.roms.single_file.extensions`
@@ -39,9 +39,9 @@ Drop files with these extensions before matching, only for files that aren't ins
 
 ```yaml
 exclude:
-  roms:
-    single_file:
-      extensions: ["xml", "txt"]
+    roms:
+        single_file:
+            extensions: ["xml", "txt"]
 ```
 
 ### `exclude.roms.single_file.names`
@@ -52,9 +52,9 @@ Unix-glob file-name patterns to skip.
 
 ```yaml
 exclude:
-  roms:
-    single_file:
-      names: ["info.txt", "._*", "*.nfo"]
+    roms:
+        single_file:
+            names: ["info.txt", "._*", "*.nfo"]
 ```
 
 ### `exclude.roms.multi_file.names`
@@ -65,9 +65,9 @@ Skip whole folders. Used for multi-disc/multi-file games you want invisible.
 
 ```yaml
 exclude:
-  roms:
-    multi_file:
-      names: ["final fantasy VII", "DLC"]
+    roms:
+        multi_file:
+            names: ["final fantasy VII", "DLC"]
 ```
 
 ### `exclude.roms.multi_file.parts.names`
@@ -78,10 +78,10 @@ Files **inside** a multi-file ROM folder to ignore (e.g. `.nfo`, `._*` macOS att
 
 ```yaml
 exclude:
-  roms:
-    multi_file:
-      parts:
-        names: ["data.xml", "._*"]
+    roms:
+        multi_file:
+            parts:
+                names: ["data.xml", "._*"]
 ```
 
 ### `exclude.roms.multi_file.parts.extensions`
@@ -92,10 +92,10 @@ Extensions to ignore inside a multi-file ROM folder.
 
 ```yaml
 exclude:
-  roms:
-    multi_file:
-      parts:
-        extensions: ["xml", "txt"]
+    roms:
+        multi_file:
+            parts:
+                extensions: ["xml", "txt"]
 ```
 
 ---
@@ -110,10 +110,10 @@ Map your folder names to [supported platform](../platforms/supported-platforms.m
 
 ```yaml
 system:
-  platforms:
-    gc: "ngc" # treat "gc/" folder as GameCube
-    psx: "ps" # treat "psx/" folder as PlayStation
-    super_nintendo: "snes"
+    platforms:
+        gc: "ngc" # treat "gc/" folder as GameCube
+        psx: "ps" # treat "psx/" folder as PlayStation
+        super_nintendo: "snes"
 ```
 
 ### `system.versions`
@@ -122,8 +122,8 @@ Associate a platform with its "main" IGDB version, for platforms that have multi
 
 ```yaml
 system:
-  versions:
-    naomi: "arcade"
+    versions:
+        naomi: "arcade"
 ```
 
 ---
@@ -136,7 +136,7 @@ Override the default ROMs folder name (`roms`).
 
 ```yaml
 filesystem:
-  roms_folder: "my_roms"
+    roms_folder: "my_roms"
 ```
 
 ### `filesystem.firmware_folder`
@@ -145,7 +145,7 @@ Override the default BIOS/firmware folder name (`bios`).
 
 ```yaml
 filesystem:
-  firmware_folder: "firmware"
+    firmware_folder: "firmware"
 ```
 
 ### `filesystem.skip_hash_calculation`
@@ -156,7 +156,7 @@ Skip hashing on low-power devices. You lose hash-based matching (RetroAchievemen
 
 ```yaml
 filesystem:
-  skip_hash_calculation: true
+    skip_hash_calculation: true
 ```
 
 ---
@@ -171,11 +171,11 @@ Order metadata providers are queried during a scan. First match wins for descrip
 
 ```yaml
 scan:
-  priority:
-    metadata:
-      - "igdb"
-      - "ss"
-      - "moby"
+    priority:
+        metadata:
+            - "igdb"
+            - "ss"
+            - "moby"
 ```
 
 Values are the provider slugs. Full list:
@@ -202,11 +202,11 @@ Same idea, for cover art and screenshots. Defaults to the same order as `scan.pr
 
 ```yaml
 scan:
-  priority:
-    artwork:
-      - "ss" # prefer ScreenScraper artwork
-      - "igdb"
-      - "moby"
+    priority:
+        artwork:
+            - "ss" # prefer ScreenScraper artwork
+            - "igdb"
+            - "moby"
 ```
 
 ### `scan.priority.region`
@@ -217,11 +217,11 @@ Preferred region for titles, cover art, and regional variants. ScreenScraper use
 
 ```yaml
 scan:
-  priority:
-    region:
-      - "us"
-      - "eu"
-      - "jp"
+    priority:
+        region:
+            - "us"
+            - "eu"
+            - "jp"
 ```
 
 ### `scan.priority.language`
@@ -232,11 +232,11 @@ Preferred localisation language.
 
 ```yaml
 scan:
-  priority:
-    language:
-      - "en"
-      - "es"
-      - "fr"
+    priority:
+        language:
+            - "en"
+            - "es"
+            - "fr"
 ```
 
 ### `scan.media`
@@ -260,11 +260,11 @@ Which media types to fetch during a scan, primarily for ScreenScraper and the ga
 
 ```yaml
 scan:
-  media:
-    - box2d
-    - screenshot
-    - manual
-    - bezel
+    media:
+        - box2d
+        - screenshot
+        - manual
+        - bezel
 ```
 
 ### `scan.gamelist.export`
@@ -273,11 +273,11 @@ Generate a `gamelist.xml` in each platform folder, compatible with ES-DE/Batocer
 
 ```yaml
 scan:
-  gamelist:
-    export: true
-    media:
-      thumbnail: box2d
-      image: screenshot
+    gamelist:
+        export: true
+        media:
+            thumbnail: box2d
+            image: screenshot
 ```
 
 ### `scan.pegasus.export`
@@ -286,8 +286,8 @@ Export metadata in Pegasus-frontend format (`metadata.pegasus.txt`).
 
 ```yaml
 scan:
-  pegasus:
-    export: true
+    pegasus:
+        export: true
 ```
 
 ---
@@ -304,7 +304,7 @@ Log available EmulatorJS options to the browser console for debugging.
 
 ```yaml
 emulatorjs:
-  debug: true
+    debug: true
 ```
 
 ### `emulatorjs.cache_limit`
@@ -313,7 +313,7 @@ Per-ROM cache limit in bytes. `null` = unlimited.
 
 ```yaml
 emulatorjs:
-  cache_limit: 52428800 # 50 MB
+    cache_limit: 52428800 # 50 MB
 ```
 
 ### `emulatorjs.disable_batch_bootup`
@@ -322,7 +322,7 @@ DOS-specific knob that skips the `autorun.bat` step. Toggle if DOS games won't b
 
 ```yaml
 emulatorjs:
-  disable_batch_bootup: true
+    disable_batch_bootup: true
 ```
 
 ### `emulatorjs.disable_auto_unload`
@@ -331,7 +331,7 @@ By default, EmulatorJS stops the emulator when you leave its page. Disable to ke
 
 ```yaml
 emulatorjs:
-  disable_auto_unload: true
+    disable_auto_unload: true
 ```
 
 ### `emulatorjs.netplay`
@@ -340,18 +340,18 @@ Toggle Netplay and configure STUN/TURN servers. Google's public STUN servers are
 
 ```yaml
 emulatorjs:
-  netplay:
-    enabled: true
-    ice_servers:
-      - urls: "stun:stun.l.google.com:19302"
-      - urls: "stun:stun1.l.google.com:19302"
-      - urls: "stun:stun2.l.google.com:19302"
-      - urls: "turn:openrelay.metered.ca:80"
-        username: "openrelayproject"
-        credential: "openrelayproject"
-      - urls: "turn:openrelay.metered.ca:443"
-        username: "openrelayproject"
-        credential: "openrelayproject"
+    netplay:
+        enabled: true
+        ice_servers:
+            - urls: "stun:stun.l.google.com:19302"
+            - urls: "stun:stun1.l.google.com:19302"
+            - urls: "stun:stun2.l.google.com:19302"
+            - urls: "turn:openrelay.metered.ca:80"
+              username: "openrelayproject"
+              credential: "openrelayproject"
+            - urls: "turn:openrelay.metered.ca:443"
+              username: "openrelayproject"
+              credential: "openrelayproject"
 ```
 
 <!-- prettier-ignore -->
@@ -364,13 +364,13 @@ Per-core emulator options. Use `default` to apply to every core.
 
 ```yaml
 emulatorjs:
-  settings:
-    parallel_n64:
-      vsync: disable
-    snes9x:
-      snes9x_region: ntsc
-    default:
-      fps: show
+    settings:
+        parallel_n64:
+            vsync: disable
+        snes9x:
+            snes9x_region: ntsc
+        default:
+            fps: show
 ```
 
 Core names must match the EmulatorJS core identifier exactly. To discover core names and per-core option keys, turn on `debug: true`, load a game in that core, open the browser console, filter for "option", and copy the keys you care about. Upstream reference is available in [EmulatorJS core options](https://emulatorjs.org/docs4devs/settings/).
@@ -381,16 +381,16 @@ Map keyboard and controller buttons per core, per player.
 
 ```yaml
 emulatorjs:
-  controls:
-    snes9x:
-      0: # player 1
-        0: # button slot
-          value: x # keyboard key
-          value2: BUTTON_2 # controller button
-      1: # player 2
-        0:
-          value: /
-          value2: BUTTON_2
+    controls:
+        snes9x:
+            0: # player 1
+                0: # button slot
+                    value: x # keyboard key
+                    value2: BUTTON_2 # controller button
+            1: # player 2
+                0:
+                    value: /
+                    value2: BUTTON_2
 ```
 
 See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/control-mapping/) for the button-slot reference. Users can override these defaults in-game via Menu → **Controls**, the config.yml setting only sets the starting point.
@@ -399,19 +399,19 @@ See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/contr
 
 ```yaml
 emulatorjs:
-  settings:
-    snes9x:
-      snes9x_region: ntsc
-  controls:
-    snes9x:
-      0: # P1 on keyboard (WASD cluster)
-        0: { value: ",", value2: "BUTTON_2" } # B
-        1: { value: ".", value2: "BUTTON_3" } # A
-        2: { value: "l", value2: "BUTTON_1" } # Y
-        3: { value: "p", value2: "BUTTON_4" } # X
-      1: # P2 on arrows + numpad
-        0: { value: "/", value2: "BUTTON_2" }
-        1: { value: "'", value2: "BUTTON_3" }
+    settings:
+        snes9x:
+            snes9x_region: ntsc
+    controls:
+        snes9x:
+            0: # P1 on keyboard (WASD cluster)
+                0: { value: ",", value2: "BUTTON_2" } # B
+                1: { value: ".", value2: "BUTTON_3" } # A
+                2: { value: "l", value2: "BUTTON_1" } # Y
+                3: { value: "p", value2: "BUTTON_4" } # X
+            1: # P2 on arrows + numpad
+                0: { value: "/", value2: "BUTTON_2" }
+                1: { value: "'", value2: "BUTTON_3" }
 ```
 
 ### Operator-level vs per-user

--- a/docs/reference/configuration-file.md
+++ b/docs/reference/configuration-file.md
@@ -246,6 +246,7 @@ Which media types to fetch during a scan, primarily for ScreenScraper and the ga
 | Type           | Description                                  |
 | -------------- | -------------------------------------------- |
 | `box2d`        | Normal 2D cover art. Always enabled.         |
+| `box2d_back`   | Back cover art.                              |
 | `box2d_side`   | 2D side/spine box art.                       |
 | `box3d`        | 3D box art.                                  |
 | `miximage`     | Composite image (box + screenshot + logo).   |

--- a/docs/reference/configuration-file.md
+++ b/docs/reference/configuration-file.md
@@ -28,7 +28,7 @@ Skip entire platform folders. Values are platform slugs, not folder names (see [
 
 ```yaml
 exclude:
-  platforms: ["ps", "ngc", "gba"]
+    platforms: ["ps", "ngc", "gba"]
 ```
 
 ### `exclude.roms.single_file.extensions`
@@ -39,9 +39,9 @@ Drop files with these extensions before matching, only for files that aren't ins
 
 ```yaml
 exclude:
-  roms:
-    single_file:
-      extensions: ["xml", "txt"]
+    roms:
+        single_file:
+            extensions: ["xml", "txt"]
 ```
 
 ### `exclude.roms.single_file.names`
@@ -52,9 +52,9 @@ Unix-glob file-name patterns to skip.
 
 ```yaml
 exclude:
-  roms:
-    single_file:
-      names: ["info.txt", "._*", "*.nfo"]
+    roms:
+        single_file:
+            names: ["info.txt", "._*", "*.nfo"]
 ```
 
 ### `exclude.roms.multi_file.names`
@@ -65,9 +65,9 @@ Skip whole folders. Used for multi-disc/multi-file games you want invisible.
 
 ```yaml
 exclude:
-  roms:
-    multi_file:
-      names: ["final fantasy VII", "DLC"]
+    roms:
+        multi_file:
+            names: ["final fantasy VII", "DLC"]
 ```
 
 ### `exclude.roms.multi_file.parts.names`
@@ -78,10 +78,10 @@ Files **inside** a multi-file ROM folder to ignore (e.g. `.nfo`, `._*` macOS att
 
 ```yaml
 exclude:
-  roms:
-    multi_file:
-      parts:
-        names: ["data.xml", "._*"]
+    roms:
+        multi_file:
+            parts:
+                names: ["data.xml", "._*"]
 ```
 
 ### `exclude.roms.multi_file.parts.extensions`
@@ -92,10 +92,10 @@ Extensions to ignore inside a multi-file ROM folder.
 
 ```yaml
 exclude:
-  roms:
-    multi_file:
-      parts:
-        extensions: ["xml", "txt"]
+    roms:
+        multi_file:
+            parts:
+                extensions: ["xml", "txt"]
 ```
 
 ---
@@ -110,10 +110,10 @@ Map your folder names to [supported platform](../platforms/supported-platforms.m
 
 ```yaml
 system:
-  platforms:
-    gc: "ngc" # treat "gc/" folder as GameCube
-    psx: "ps" # treat "psx/" folder as PlayStation
-    super_nintendo: "snes"
+    platforms:
+        gc: "ngc" # treat "gc/" folder as GameCube
+        psx: "ps" # treat "psx/" folder as PlayStation
+        super_nintendo: "snes"
 ```
 
 ### `system.versions`
@@ -122,8 +122,8 @@ Associate a platform with its "main" IGDB version, for platforms that have multi
 
 ```yaml
 system:
-  versions:
-    naomi: "arcade"
+    versions:
+        naomi: "arcade"
 ```
 
 ---
@@ -136,7 +136,7 @@ Override the default ROMs folder name (`roms`).
 
 ```yaml
 filesystem:
-  roms_folder: "my_roms"
+    roms_folder: "my_roms"
 ```
 
 ### `filesystem.firmware_folder`
@@ -145,7 +145,7 @@ Override the default BIOS/firmware folder name (`bios`).
 
 ```yaml
 filesystem:
-  firmware_folder: "firmware"
+    firmware_folder: "firmware"
 ```
 
 ### `filesystem.skip_hash_calculation`
@@ -156,7 +156,7 @@ Skip hashing on low-power devices. You lose hash-based matching (RetroAchievemen
 
 ```yaml
 filesystem:
-  skip_hash_calculation: true
+    skip_hash_calculation: true
 ```
 
 ---
@@ -171,11 +171,11 @@ Order metadata providers are queried during a scan. First match wins for descrip
 
 ```yaml
 scan:
-  priority:
-    metadata:
-      - "igdb"
-      - "ss"
-      - "moby"
+    priority:
+        metadata:
+            - "igdb"
+            - "ss"
+            - "moby"
 ```
 
 Values are the provider slugs. Full list:
@@ -202,11 +202,11 @@ Same idea, for cover art and screenshots. Defaults to the same order as `scan.pr
 
 ```yaml
 scan:
-  priority:
-    artwork:
-      - "ss" # prefer ScreenScraper artwork
-      - "igdb"
-      - "moby"
+    priority:
+        artwork:
+            - "ss" # prefer ScreenScraper artwork
+            - "igdb"
+            - "moby"
 ```
 
 ### `scan.priority.region`
@@ -217,11 +217,11 @@ Preferred region for titles, cover art, and regional variants. ScreenScraper use
 
 ```yaml
 scan:
-  priority:
-    region:
-      - "us"
-      - "eu"
-      - "jp"
+    priority:
+        region:
+            - "us"
+            - "eu"
+            - "jp"
 ```
 
 ### `scan.priority.language`
@@ -232,11 +232,11 @@ Preferred localisation language.
 
 ```yaml
 scan:
-  priority:
-    language:
-      - "en"
-      - "es"
-      - "fr"
+    priority:
+        language:
+            - "en"
+            - "es"
+            - "fr"
 ```
 
 ### `scan.media`
@@ -264,11 +264,11 @@ Which media types to fetch during a scan, primarily for ScreenScraper and the ga
 
 ```yaml
 scan:
-  media:
-    - box2d
-    - screenshot
-    - manual
-    - bezel
+    media:
+        - box2d
+        - screenshot
+        - manual
+        - bezel
 ```
 
 ### `scan.gamelist.export`
@@ -277,11 +277,11 @@ Generate a `gamelist.xml` in each platform folder, compatible with ES-DE/Batocer
 
 ```yaml
 scan:
-  gamelist:
-    export: true
-    media:
-      thumbnail: box2d
-      image: screenshot
+    gamelist:
+        export: true
+        media:
+            thumbnail: box2d
+            image: screenshot
 ```
 
 ### `scan.pegasus.export`
@@ -290,8 +290,8 @@ Export metadata in Pegasus-frontend format (`metadata.pegasus.txt`).
 
 ```yaml
 scan:
-  pegasus:
-    export: true
+    pegasus:
+        export: true
 ```
 
 ---
@@ -308,7 +308,7 @@ Log available EmulatorJS options to the browser console for debugging.
 
 ```yaml
 emulatorjs:
-  debug: true
+    debug: true
 ```
 
 ### `emulatorjs.cache_limit`
@@ -317,7 +317,7 @@ Per-ROM cache limit in bytes. `null` = unlimited.
 
 ```yaml
 emulatorjs:
-  cache_limit: 52428800 # 50 MB
+    cache_limit: 52428800 # 50 MB
 ```
 
 ### `emulatorjs.disable_batch_bootup`
@@ -326,7 +326,7 @@ DOS-specific knob that skips the `autorun.bat` step. Toggle if DOS games won't b
 
 ```yaml
 emulatorjs:
-  disable_batch_bootup: true
+    disable_batch_bootup: true
 ```
 
 ### `emulatorjs.disable_auto_unload`
@@ -335,7 +335,7 @@ By default, EmulatorJS stops the emulator when you leave its page. Disable to ke
 
 ```yaml
 emulatorjs:
-  disable_auto_unload: true
+    disable_auto_unload: true
 ```
 
 ### `emulatorjs.netplay`
@@ -344,18 +344,18 @@ Toggle Netplay and configure STUN/TURN servers. Google's public STUN servers are
 
 ```yaml
 emulatorjs:
-  netplay:
-    enabled: true
-    ice_servers:
-      - urls: "stun:stun.l.google.com:19302"
-      - urls: "stun:stun1.l.google.com:19302"
-      - urls: "stun:stun2.l.google.com:19302"
-      - urls: "turn:openrelay.metered.ca:80"
-        username: "openrelayproject"
-        credential: "openrelayproject"
-      - urls: "turn:openrelay.metered.ca:443"
-        username: "openrelayproject"
-        credential: "openrelayproject"
+    netplay:
+        enabled: true
+        ice_servers:
+            - urls: "stun:stun.l.google.com:19302"
+            - urls: "stun:stun1.l.google.com:19302"
+            - urls: "stun:stun2.l.google.com:19302"
+            - urls: "turn:openrelay.metered.ca:80"
+              username: "openrelayproject"
+              credential: "openrelayproject"
+            - urls: "turn:openrelay.metered.ca:443"
+              username: "openrelayproject"
+              credential: "openrelayproject"
 ```
 
 <!-- prettier-ignore -->
@@ -368,13 +368,13 @@ Per-core emulator options. Use `default` to apply to every core.
 
 ```yaml
 emulatorjs:
-  settings:
-    parallel_n64:
-      vsync: disable
-    snes9x:
-      snes9x_region: ntsc
-    default:
-      fps: show
+    settings:
+        parallel_n64:
+            vsync: disable
+        snes9x:
+            snes9x_region: ntsc
+        default:
+            fps: show
 ```
 
 Core names must match the EmulatorJS core identifier exactly. To discover core names and per-core option keys, turn on `debug: true`, load a game in that core, open the browser console, filter for "option", and copy the keys you care about. Upstream reference is available in [EmulatorJS core options](https://emulatorjs.org/docs4devs/settings/).
@@ -385,16 +385,16 @@ Map keyboard and controller buttons per core, per player.
 
 ```yaml
 emulatorjs:
-  controls:
-    snes9x:
-      0: # player 1
-        0: # button slot
-          value: x # keyboard key
-          value2: BUTTON_2 # controller button
-      1: # player 2
-        0:
-          value: /
-          value2: BUTTON_2
+    controls:
+        snes9x:
+            0: # player 1
+                0: # button slot
+                    value: x # keyboard key
+                    value2: BUTTON_2 # controller button
+            1: # player 2
+                0:
+                    value: /
+                    value2: BUTTON_2
 ```
 
 See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/control-mapping/) for the button-slot reference. Users can override these defaults in-game via Menu → **Controls**, the config.yml setting only sets the starting point.
@@ -403,19 +403,19 @@ See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/contr
 
 ```yaml
 emulatorjs:
-  settings:
-    snes9x:
-      snes9x_region: ntsc
-  controls:
-    snes9x:
-      0: # P1 on keyboard (WASD cluster)
-        0: { value: ",", value2: "BUTTON_2" } # B
-        1: { value: ".", value2: "BUTTON_3" } # A
-        2: { value: "l", value2: "BUTTON_1" } # Y
-        3: { value: "p", value2: "BUTTON_4" } # X
-      1: # P2 on arrows + numpad
-        0: { value: "/", value2: "BUTTON_2" }
-        1: { value: "'", value2: "BUTTON_3" }
+    settings:
+        snes9x:
+            snes9x_region: ntsc
+    controls:
+        snes9x:
+            0: # P1 on keyboard (WASD cluster)
+                0: { value: ",", value2: "BUTTON_2" } # B
+                1: { value: ".", value2: "BUTTON_3" } # A
+                2: { value: "l", value2: "BUTTON_1" } # Y
+                3: { value: "p", value2: "BUTTON_4" } # X
+            1: # P2 on arrows + numpad
+                0: { value: "/", value2: "BUTTON_2" }
+                1: { value: "'", value2: "BUTTON_3" }
 ```
 
 ### Operator-level vs per-user

--- a/docs/reference/configuration-file.md
+++ b/docs/reference/configuration-file.md
@@ -28,7 +28,7 @@ Skip entire platform folders. Values are platform slugs, not folder names (see [
 
 ```yaml
 exclude:
-    platforms: ["ps", "ngc", "gba"]
+  platforms: ["ps", "ngc", "gba"]
 ```
 
 ### `exclude.roms.single_file.extensions`
@@ -39,9 +39,9 @@ Drop files with these extensions before matching, only for files that aren't ins
 
 ```yaml
 exclude:
-    roms:
-        single_file:
-            extensions: ["xml", "txt"]
+  roms:
+    single_file:
+      extensions: ["xml", "txt"]
 ```
 
 ### `exclude.roms.single_file.names`
@@ -52,9 +52,9 @@ Unix-glob file-name patterns to skip.
 
 ```yaml
 exclude:
-    roms:
-        single_file:
-            names: ["info.txt", "._*", "*.nfo"]
+  roms:
+    single_file:
+      names: ["info.txt", "._*", "*.nfo"]
 ```
 
 ### `exclude.roms.multi_file.names`
@@ -65,9 +65,9 @@ Skip whole folders. Used for multi-disc/multi-file games you want invisible.
 
 ```yaml
 exclude:
-    roms:
-        multi_file:
-            names: ["final fantasy VII", "DLC"]
+  roms:
+    multi_file:
+      names: ["final fantasy VII", "DLC"]
 ```
 
 ### `exclude.roms.multi_file.parts.names`
@@ -78,10 +78,10 @@ Files **inside** a multi-file ROM folder to ignore (e.g. `.nfo`, `._*` macOS att
 
 ```yaml
 exclude:
-    roms:
-        multi_file:
-            parts:
-                names: ["data.xml", "._*"]
+  roms:
+    multi_file:
+      parts:
+        names: ["data.xml", "._*"]
 ```
 
 ### `exclude.roms.multi_file.parts.extensions`
@@ -92,10 +92,10 @@ Extensions to ignore inside a multi-file ROM folder.
 
 ```yaml
 exclude:
-    roms:
-        multi_file:
-            parts:
-                extensions: ["xml", "txt"]
+  roms:
+    multi_file:
+      parts:
+        extensions: ["xml", "txt"]
 ```
 
 ---
@@ -110,10 +110,10 @@ Map your folder names to [supported platform](../platforms/supported-platforms.m
 
 ```yaml
 system:
-    platforms:
-        gc: "ngc" # treat "gc/" folder as GameCube
-        psx: "ps" # treat "psx/" folder as PlayStation
-        super_nintendo: "snes"
+  platforms:
+    gc: "ngc" # treat "gc/" folder as GameCube
+    psx: "ps" # treat "psx/" folder as PlayStation
+    super_nintendo: "snes"
 ```
 
 ### `system.versions`
@@ -122,8 +122,8 @@ Associate a platform with its "main" IGDB version, for platforms that have multi
 
 ```yaml
 system:
-    versions:
-        naomi: "arcade"
+  versions:
+    naomi: "arcade"
 ```
 
 ---
@@ -136,7 +136,7 @@ Override the default ROMs folder name (`roms`).
 
 ```yaml
 filesystem:
-    roms_folder: "my_roms"
+  roms_folder: "my_roms"
 ```
 
 ### `filesystem.firmware_folder`
@@ -145,7 +145,7 @@ Override the default BIOS/firmware folder name (`bios`).
 
 ```yaml
 filesystem:
-    firmware_folder: "firmware"
+  firmware_folder: "firmware"
 ```
 
 ### `filesystem.skip_hash_calculation`
@@ -156,7 +156,7 @@ Skip hashing on low-power devices. You lose hash-based matching (RetroAchievemen
 
 ```yaml
 filesystem:
-    skip_hash_calculation: true
+  skip_hash_calculation: true
 ```
 
 ---
@@ -171,11 +171,11 @@ Order metadata providers are queried during a scan. First match wins for descrip
 
 ```yaml
 scan:
-    priority:
-        metadata:
-            - "igdb"
-            - "ss"
-            - "moby"
+  priority:
+    metadata:
+      - "igdb"
+      - "ss"
+      - "moby"
 ```
 
 Values are the provider slugs. Full list:
@@ -202,11 +202,11 @@ Same idea, for cover art and screenshots. Defaults to the same order as `scan.pr
 
 ```yaml
 scan:
-    priority:
-        artwork:
-            - "ss" # prefer ScreenScraper artwork
-            - "igdb"
-            - "moby"
+  priority:
+    artwork:
+      - "ss" # prefer ScreenScraper artwork
+      - "igdb"
+      - "moby"
 ```
 
 ### `scan.priority.region`
@@ -217,11 +217,11 @@ Preferred region for titles, cover art, and regional variants. ScreenScraper use
 
 ```yaml
 scan:
-    priority:
-        region:
-            - "us"
-            - "eu"
-            - "jp"
+  priority:
+    region:
+      - "us"
+      - "eu"
+      - "jp"
 ```
 
 ### `scan.priority.language`
@@ -232,11 +232,11 @@ Preferred localisation language.
 
 ```yaml
 scan:
-    priority:
-        language:
-            - "en"
-            - "es"
-            - "fr"
+  priority:
+    language:
+      - "en"
+      - "es"
+      - "fr"
 ```
 
 ### `scan.media`
@@ -246,6 +246,7 @@ Which media types to fetch during a scan, primarily for ScreenScraper and the ga
 | Type           | Description                                  |
 | -------------- | -------------------------------------------- |
 | `box2d`        | Normal 2D cover art. Always enabled.         |
+| `box2d_side`   | 2D side/spine box art.                       |
 | `box3d`        | 3D box art.                                  |
 | `miximage`     | Composite image (box + screenshot + logo).   |
 | `physical`     | Physical media (disc, cartridge).            |
@@ -259,11 +260,11 @@ Which media types to fetch during a scan, primarily for ScreenScraper and the ga
 
 ```yaml
 scan:
-    media:
-        - box2d
-        - screenshot
-        - manual
-        - bezel
+  media:
+    - box2d
+    - screenshot
+    - manual
+    - bezel
 ```
 
 ### `scan.gamelist.export`
@@ -272,11 +273,11 @@ Generate a `gamelist.xml` in each platform folder, compatible with ES-DE/Batocer
 
 ```yaml
 scan:
-    gamelist:
-        export: true
-        media:
-            thumbnail: box2d
-            image: screenshot
+  gamelist:
+    export: true
+    media:
+      thumbnail: box2d
+      image: screenshot
 ```
 
 ### `scan.pegasus.export`
@@ -285,8 +286,8 @@ Export metadata in Pegasus-frontend format (`metadata.pegasus.txt`).
 
 ```yaml
 scan:
-    pegasus:
-        export: true
+  pegasus:
+    export: true
 ```
 
 ---
@@ -303,7 +304,7 @@ Log available EmulatorJS options to the browser console for debugging.
 
 ```yaml
 emulatorjs:
-    debug: true
+  debug: true
 ```
 
 ### `emulatorjs.cache_limit`
@@ -312,7 +313,7 @@ Per-ROM cache limit in bytes. `null` = unlimited.
 
 ```yaml
 emulatorjs:
-    cache_limit: 52428800 # 50 MB
+  cache_limit: 52428800 # 50 MB
 ```
 
 ### `emulatorjs.disable_batch_bootup`
@@ -321,7 +322,7 @@ DOS-specific knob that skips the `autorun.bat` step. Toggle if DOS games won't b
 
 ```yaml
 emulatorjs:
-    disable_batch_bootup: true
+  disable_batch_bootup: true
 ```
 
 ### `emulatorjs.disable_auto_unload`
@@ -330,7 +331,7 @@ By default, EmulatorJS stops the emulator when you leave its page. Disable to ke
 
 ```yaml
 emulatorjs:
-    disable_auto_unload: true
+  disable_auto_unload: true
 ```
 
 ### `emulatorjs.netplay`
@@ -339,18 +340,18 @@ Toggle Netplay and configure STUN/TURN servers. Google's public STUN servers are
 
 ```yaml
 emulatorjs:
-    netplay:
-        enabled: true
-        ice_servers:
-            - urls: "stun:stun.l.google.com:19302"
-            - urls: "stun:stun1.l.google.com:19302"
-            - urls: "stun:stun2.l.google.com:19302"
-            - urls: "turn:openrelay.metered.ca:80"
-              username: "openrelayproject"
-              credential: "openrelayproject"
-            - urls: "turn:openrelay.metered.ca:443"
-              username: "openrelayproject"
-              credential: "openrelayproject"
+  netplay:
+    enabled: true
+    ice_servers:
+      - urls: "stun:stun.l.google.com:19302"
+      - urls: "stun:stun1.l.google.com:19302"
+      - urls: "stun:stun2.l.google.com:19302"
+      - urls: "turn:openrelay.metered.ca:80"
+        username: "openrelayproject"
+        credential: "openrelayproject"
+      - urls: "turn:openrelay.metered.ca:443"
+        username: "openrelayproject"
+        credential: "openrelayproject"
 ```
 
 <!-- prettier-ignore -->
@@ -363,13 +364,13 @@ Per-core emulator options. Use `default` to apply to every core.
 
 ```yaml
 emulatorjs:
-    settings:
-        parallel_n64:
-            vsync: disable
-        snes9x:
-            snes9x_region: ntsc
-        default:
-            fps: show
+  settings:
+    parallel_n64:
+      vsync: disable
+    snes9x:
+      snes9x_region: ntsc
+    default:
+      fps: show
 ```
 
 Core names must match the EmulatorJS core identifier exactly. To discover core names and per-core option keys, turn on `debug: true`, load a game in that core, open the browser console, filter for "option", and copy the keys you care about. Upstream reference is available in [EmulatorJS core options](https://emulatorjs.org/docs4devs/settings/).
@@ -380,16 +381,16 @@ Map keyboard and controller buttons per core, per player.
 
 ```yaml
 emulatorjs:
-    controls:
-        snes9x:
-            0: # player 1
-                0: # button slot
-                    value: x # keyboard key
-                    value2: BUTTON_2 # controller button
-            1: # player 2
-                0:
-                    value: /
-                    value2: BUTTON_2
+  controls:
+    snes9x:
+      0: # player 1
+        0: # button slot
+          value: x # keyboard key
+          value2: BUTTON_2 # controller button
+      1: # player 2
+        0:
+          value: /
+          value2: BUTTON_2
 ```
 
 See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/control-mapping/) for the button-slot reference. Users can override these defaults in-game via Menu → **Controls**, the config.yml setting only sets the starting point.
@@ -398,19 +399,19 @@ See the [EmulatorJS control-mapping docs](https://emulatorjs.org/docs4devs/contr
 
 ```yaml
 emulatorjs:
-    settings:
-        snes9x:
-            snes9x_region: ntsc
-    controls:
-        snes9x:
-            0: # P1 on keyboard (WASD cluster)
-                0: { value: ",", value2: "BUTTON_2" } # B
-                1: { value: ".", value2: "BUTTON_3" } # A
-                2: { value: "l", value2: "BUTTON_1" } # Y
-                3: { value: "p", value2: "BUTTON_4" } # X
-            1: # P2 on arrows + numpad
-                0: { value: "/", value2: "BUTTON_2" }
-                1: { value: "'", value2: "BUTTON_3" }
+  settings:
+    snes9x:
+      snes9x_region: ntsc
+  controls:
+    snes9x:
+      0: # P1 on keyboard (WASD cluster)
+        0: { value: ",", value2: "BUTTON_2" } # B
+        1: { value: ".", value2: "BUTTON_3" } # A
+        2: { value: "l", value2: "BUTTON_1" } # Y
+        3: { value: "p", value2: "BUTTON_4" } # X
+      1: # P2 on arrows + numpad
+        0: { value: "/", value2: "BUTTON_2" }
+        1: { value: "'", value2: "BUTTON_3" }
 ```
 
 ### Operator-level vs per-user

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -29,13 +29,11 @@ Every term the docs, UI, and API use consistently, with foundational concepts ge
 
 **Device**: a registered endpoint that syncs with RomM, such as a handheld running Grout, an Android phone running Argosy, or a SteamDeck running DeckRommSync. Devices pull saves and states, and some push them back after a session (see [Device Sync Protocol](../developers/device-sync-protocol.md)).
 
-**Editor**: mid-tier user role. Edits content (ROMs, platforms, collections) and uploads, but no user management (see [Users & Roles](../administration/users-and-roles.md)).
-
 **EmulatorJS**: the bundled in-browser retro emulator. Handles NES, SNES, N64, PSX, Saturn, and 20+ more cores (see [In-Browser Play → EmulatorJS](../using/in-browser-play/emulatorjs.md)).
 
 **Feed**: a URL endpoint that exposes a filtered library view in a third-party tool's expected format (see [Feed Clients](../ecosystem/feed-clients.md)).
 
-**Firmware**: BIOS or system firmware required for certain emulators (PS1, GBA, Saturn, etc.). Lives under `/romm/library/bios/{platform}/` or `/romm/library/{platform}/bios/` (depending on which folder structure you chose). Uploaded via the UI and managed by admins/editors (see [Firmware Management](../administration/firmware-management.md)).
+**Firmware**: BIOS or system firmware required for certain emulators (PS1, GBA, Saturn, etc.). Lives under `/romm/library/bios/{platform}/` or `/romm/library/{platform}/bios/` (depending on which folder structure you chose). Uploaded via the UI and managed by admins and users with the `firmware.write` scope (see [Firmware Management](../administration/firmware-management.md)).
 
 **Full image**: the default container variant, including EmulatorJS + Ruffle. `rommapp/romm:X.Y.Z` (see [Image Variants](../install/image-variants.md)).
 
@@ -59,6 +57,8 @@ Every term the docs, UI, and API use consistently, with foundational concepts ge
 
 **OpenTelemetry (OTEL)**: opt-in traces/metrics/logs export. `OTEL_ENABLED=true` (see [Observability](../administration/observability.md)).
 
+**Permission group**: a named template of capabilities (a grant matrix over entity types × `read`/`write`/`delete`) assigned to a User. One group is the server-wide default for new users. Admins bypass groups entirely (see [Users & Roles](../administration/users-and-roles.md#permission-groups)).
+
 **Personal tab**: the ROM detail page tab for per-user data (rating, status, notes, playtime).
 
 **Platform**: a gaming system: SNES, PlayStation, Game Boy Advance, DOS, etc. ~400 platforms ship supported. Each has a **slug** (`snes`, `ps`, `gba`) that doubles as the folder name expected in your library. Override the folder-name → slug mapping via `config.yml` (see [Supported Platforms](../platforms/supported-platforms.md)).
@@ -71,13 +71,13 @@ Every term the docs, UI, and API use consistently, with foundational concepts ge
 
 **ROM**: a single game entry. One filesystem file, one folder of files (multi-disc, patched, with DLC), or a manual DB entry. Each ROM belongs to exactly one platform. ROMs get metadata (cover, description, ratings, related games), user data (per-user rating, notes, playtime), and optional assets (saves, states, screenshots, firmware).
 
-**Role**: a convenience bundle of scopes. Three roles: Viewer, Editor, Admin (see [Users & Roles](../administration/users-and-roles.md)).
+**Role**: an account's top-level type. Two roles: User (access governed by a permission group) and Admin (full access, bypasses groups). See [Users & Roles](../administration/users-and-roles.md).
 
 **Ruffle**: the bundled in-browser Flash/Shockwave emulator (see [In-Browser Play → Ruffle](../using/in-browser-play/ruffle.md)).
 
 **Scan**: the process of walking the library, hashing files, calling metadata providers, and updating the DB. Scans run in six **modes** (New Platforms, Quick, Unmatched, Update, Hashes, Complete) and can be triggered manually, on a cron, or by the filesystem watcher (see [Scanning & Watcher](../administration/scanning-and-watcher.md)).
 
-**Scope**: fine-grained permission. 19 in total, grouped into roles. Tokens and OIDC sessions carry subsets of scopes. Every endpoint requires specific scopes. See the [scope matrix](../administration/users-and-roles.md#scope-matrix).
+**Scope**: a coarse OAuth permission derived from a user's effective [permission-group](../administration/users-and-roles.md#permission-groups) grants. Client API Tokens and OIDC sessions carry a subset of the user's scopes (see [Users & Roles → API tokens](../administration/users-and-roles.md#api-tokens-advanced)).
 
 **Setup Wizard**: first-run flow that creates the admin user. Shown before any user exists.
 
@@ -89,11 +89,9 @@ Every term the docs, UI, and API use consistently, with foundational concepts ge
 
 **Tinfoil**: Nintendo Switch homebrew that installs from RomM's feed (see [Tinfoil](../ecosystem/feed-clients.md#tinfoil)).
 
-**User**: an account with a role (Viewer, Editor, Admin) and a set of scopes. Can be created by the Setup Wizard, an admin, an invite link, public registration, or OIDC auto-provisioning (see [Users & Roles](../administration/users-and-roles.md)).
+**User**: an account. Its role is either User (access from a permission group plus per-user overrides) or Admin (full access). Can be created by the Setup Wizard, an admin, an invite link, or OIDC auto-provisioning (see [Users & Roles](../administration/users-and-roles.md)).
 
 **Valkey**: open-source Redis fork, drop-in compatible (see [Redis or Valkey](../install/redis-or-valkey.md)).
-
-**Viewer**: lowest user role. Read-only on library, own saves/states/profile (see [Users & Roles](../administration/users-and-roles.md)).
 
 **Virtual Collection**: auto-generated collection by genre/developer/year/tag. Read-only (see [Virtual Collections](../using/virtual-collections.md)).
 

--- a/docs/resources/snippets/env-vars.md
+++ b/docs/resources/snippets/env-vars.md
@@ -47,27 +47,29 @@
 | `DISABLE_CSRF_PROTECTION`            | `false`   |          | Disable CSRF protection (not recommended)                  |
 | `DISABLE_USERPASS_LOGIN`             | `false`   |          | Disable username/password login when using OIDC            |
 | `DISABLE_SETUP_WIZARD`               | `false`   |          | Skip the first-boot setup wizard                           |
+| `DISABLE_LOGS_VIEWER`                | `false`   |          | Disable the backend logs viewer                            |
 
 ### OpenID Connect
 
-| Variable                      | Default              | Required | Description                                              |
-| ----------------------------- | -------------------- | :------: | -------------------------------------------------------- |
-| `OIDC_ENABLED`                | `false`              |          | Enable OpenID Connect authentication                     |
-| `OIDC_AUTOLOGIN`              | `false`              |          | Skip the OIDC button on the login page and auto-redirect |
-| `OIDC_PROVIDER`               |                      |          | Name of the OIDC provider in use                         |
-| `OIDC_CLIENT_ID`              |                      |          | Client ID for OIDC authentication                        |
-| `OIDC_CLIENT_SECRET`          |                      |          | Client secret for OIDC authentication                    |
-| `OIDC_REDIRECT_URI`           |                      |          | Absolute redirect URI for OIDC authentication            |
-| `OIDC_SERVER_APPLICATION_URL` |                      |          | Absolute URL of the OIDC server application              |
-| `OIDC_SERVER_METADATA_URL`    |                      |          | URL to the OIDC provider metadata endpoint               |
-| `OIDC_CLAIM_ROLES`            |                      |          | OIDC claim containing user roles                         |
-| `OIDC_ROLE_VIEWER`            |                      |          | Role value mapping to viewer permissions                 |
-| `OIDC_ROLE_EDITOR`            |                      |          | Role value mapping to editor permissions                 |
-| `OIDC_ROLE_ADMIN`             |                      |          | Role value mapping to admin permissions                  |
-| `OIDC_TLS_CACERTFILE`         |                      |          | Path to file containing trusted CA certificates          |
-| `OIDC_USERNAME_ATTRIBUTE`     | `preferred_username` |          | Attribute on OIDC user info used as the username         |
-| `OIDC_RP_INITIATED_LOGOUT`    | `false`              |          | Enable RP-initiated logout flow                          |
-| `OIDC_END_SESSION_ENDPOINT`   |                      |          | OIDC end-session endpoint override URL                   |
+| Variable                      | Default              | Required | Description                                                        |
+| ----------------------------- | -------------------- | :------: | ------------------------------------------------------------------ |
+| `OIDC_ENABLED`                | `false`              |          | Enable OpenID Connect authentication                               |
+| `OIDC_AUTOLOGIN`              | `false`              |          | Skip the OIDC button on the login page and auto-redirect           |
+| `OIDC_ALLOW_REGISTRATION`     | `true`               |          | Allow new accounts to be created automatically on first OIDC login |
+| `OIDC_PROVIDER`               |                      |          | Name of the OIDC provider in use                                   |
+| `OIDC_CLIENT_ID`              |                      |          | Client ID for OIDC authentication                                  |
+| `OIDC_CLIENT_SECRET`          |                      |          | Client secret for OIDC authentication                              |
+| `OIDC_REDIRECT_URI`           |                      |          | Absolute redirect URI for OIDC authentication                      |
+| `OIDC_SERVER_APPLICATION_URL` |                      |          | Absolute URL of the OIDC server application                        |
+| `OIDC_SERVER_METADATA_URL`    |                      |          | URL to the OIDC provider metadata endpoint                         |
+| `OIDC_CLAIM_ROLES`            |                      |          | OIDC claim containing user roles                                   |
+| `OIDC_ROLE_VIEWER`            |                      |          | Role value mapping to viewer permissions                           |
+| `OIDC_ROLE_EDITOR`            |                      |          | Role value mapping to editor permissions                           |
+| `OIDC_ROLE_ADMIN`             |                      |          | Role value mapping to admin permissions                            |
+| `OIDC_TLS_CACERTFILE`         |                      |          | Path to file containing trusted CA certificates                    |
+| `OIDC_USERNAME_ATTRIBUTE`     | `preferred_username` |          | Attribute on OIDC user info used as the username                   |
+| `OIDC_RP_INITIATED_LOGOUT`    | `false`              |          | Enable RP-initiated logout flow                                    |
+| `OIDC_END_SESSION_ENDPOINT`   |                      |          | OIDC end-session endpoint override URL                             |
 
 ### Metadata Providers
 

--- a/docs/troubleshooting/authentication.md
+++ b/docs/troubleshooting/authentication.md
@@ -65,7 +65,7 @@ The `OIDC_REDIRECT_URI` in the env doesn't **exactly** match what's registered a
 - **Host**: `demo.romm.app` vs `www.demo.romm.app` vs the bare IP
 - **Port**: implied `80`/`443` on HTTPS vs an explicit port
 
-### User is created but stays Viewer, even though they should be Admin
+### User is created but stays a regular User, even though they should be Admin
 
 You configured `OIDC_CLAIM_ROLES` but it's not being honoured.
 

--- a/docs/using/account-and-profile.md
+++ b/docs/using/account-and-profile.md
@@ -5,7 +5,7 @@ description: Manage your user account
 
 # Account & Profile
 
-Every user (Viewer, Editor, Admin) can manage their own profile, but Admins can edit _other_ users' profiles (see [Users & Roles](../administration/users-and-roles.md) for the admin side).
+Every user (User or Admin) can manage their own profile, but Admins can edit _other_ users' profiles (see [Users & Roles](../administration/users-and-roles.md) for the admin side).
 
 ## Preferred username in OIDC
 

--- a/docs/using/collections.md
+++ b/docs/using/collections.md
@@ -34,5 +34,3 @@ Don't use a standard collection for things that have better solutions:
 | Edit own collection                      | `collections.write` |
 | Make a collection public                 | `collections.write` |
 | See all users' collections (admin panel) | Admin               |
-
-`collections.read`/`collections.write` come from a user's [permission group](../administration/users-and-roles.md#permission-groups); Admins have everything.

--- a/docs/using/collections.md
+++ b/docs/using/collections.md
@@ -27,10 +27,12 @@ Don't use a standard collection for things that have better solutions:
 
 ## Permissions
 
-| Action                                   | Viewer | Editor | Admin |
-| ---------------------------------------- | :----: | :----: | :---: |
-| See public collections                   |   ✓    |   ✓    |   ✓   |
-| Create own private collection            |   ✓    |   ✓    |   ✓   |
-| Edit own collection                      |   ✓    |   ✓    |   ✓   |
-| Make a collection public                 |   -    |   ✓    |   ✓   |
-| See all users' collections (admin panel) |   -    |   -    |   ✓   |
+| Action                                   | Scope required      |
+| ---------------------------------------- | ------------------- |
+| See public collections                   | `collections.read`  |
+| Create own private collection            | `collections.read`  |
+| Edit own collection                      | `collections.write` |
+| Make a collection public                 | `collections.write` |
+| See all users' collections (admin panel) | Admin               |
+
+`collections.read`/`collections.write` come from a user's [permission group](../administration/users-and-roles.md#permission-groups); Admins have everything.

--- a/docs/using/languages.md
+++ b/docs/using/languages.md
@@ -28,6 +28,7 @@ Pick the language you want for the UI, with the choice stored server-side so it 
 | `bg_BG` | Bulgarian                        |
 | `zh_CN` | Chinese (Simplified)             |
 | `zh_TW` | Chinese (Traditional)            |
+| `tr_TR` | Turkish                          |
 
 ## What gets translated
 

--- a/docs/using/netplay.md
+++ b/docs/using/netplay.md
@@ -38,7 +38,7 @@ WebRTC, the protocol Netplay uses, needs help to punch through some consumer rou
 
 - **Not all cores support Netplay!** SNES9x, Mupen64Plus, Mednafen PSX, Genesis Plus GX are the most battle-tested.
 - **Frame-perfect fighting isn't realistic.** Netplay is for casual co-op, not tournament-level fighting games, use something like [FightCade](https://www.fightcade.com/) for that.
-- **All players need an account.** There's no "join a friend's game without an account", guests need at least a Viewer account on your instance.
+- **All players need an account.** There's no "join a friend's game without an account", guests need at least a User account on your instance.
 - **RTC over TURN uses real bandwidth.** Hosting a 4-player N64 session over TURN can saturate a modest uplink.
 
 ## Security

--- a/docs/using/rom-patcher.md
+++ b/docs/using/rom-patcher.md
@@ -55,8 +55,6 @@ If your patch has an unusual extension, try renaming to one of the above. Many a
 | Apply patch → download    | `roms.read`    |
 | Apply patch → upload back | `roms.write`   |
 
-Scopes come from the user's [permission group](../administration/users-and-roles.md#permission-groups) or an override; Admins can do both.
-
 ## Limits
 
 - **File size**: the ROM and the patch must each stay under `ROM_PATCHER_MAX_FILE_SIZE_BYTES` (default **4 GiB**). patcherjs loads the whole file into memory server-side, so oversized inputs are rejected with a `400`.

--- a/docs/using/rom-patcher.md
+++ b/docs/using/rom-patcher.md
@@ -1,60 +1,72 @@
 ---
 title: ROM Patcher
-description: Apply IPS, UPS, BPS, PPF, and other patch formats in your browser
+description: Apply IPS, UPS, BPS, PPF, and other patch formats on the server
 ---
 
 # ROM Patcher
 
-The **ROM Patcher** applies a patch file (translation, hack, rebalance, no-intro fix) to a ROM **in your browser**: no CLI, no downloads, and no uploading half-patched files by hand.
-
-## Supported patch formats
-
-| Extension             | Purpose                                                  |
-| --------------------- | -------------------------------------------------------- |
-| `.ips`                | International Patching System. Oldest + most common.     |
-| `.ups`                | Universal Patching System. Successor to IPS.             |
-| `.bps`                | Binary Patch System. Modern, preferred for ROM hacks.    |
-| `.ppf`                | PlayStation Patch Format. For PSX/Saturn/Dreamcast ISOs. |
-| `.rup`                | Retroarch Universal Patch.                               |
-| `.aps`                | GBA-focused patch format.                                |
-| `.bdf`                | Binary diff format.                                      |
-| `.pmsr`               | Paper Mario Star Rod.                                    |
-| `.vcdiff` (`.xdelta`) | Generic binary diff.                                     |
-
-If your patch has an unusual extension, try renaming to one of the above. Many are just different framings of the same underlying algorithm.
-
-## Patching options
-
-Two output paths:
-
-- **Download patched ROM**: saves a file locally, nothing leaves your machine as everything runs client-side.
-- **Save to library**: Store the patched ROM in your library. Goes in the same platform folder as the original, with the patched filename, where the next scan will pick it up as a new entry.
-
-Metadata isn't inherited, so the new ROM is **unmatched** until you run a scan!
+The **ROM Patcher** applies a patch file (translation, hack, rebalance, no-intro fix) to a ROM **on the server**: no CLI, no local tooling, and no uploading half-patched files by hand. It's a **Patcher tab** on the game's detail page, powered by patcherjs.
 
 <!-- prettier-ignore -->
 !!! note "Server-side patching (5.0+)"
-    RomM 5.0 can also apply a patch **on the server** and store the result directly, which sidesteps the browser-memory limits below for very large ISOs. The supported formats and permission requirements are the same as the in-browser path.
+    Earlier versions patched in the browser. As of 5.0, patching runs entirely on the server: you pick a base ROM and a patch from your library, RomM applies it server-side, and streams the result back. This removes the browser-memory ceiling that used to break large ISOs.
+
+## How it works
+
+1. Open a game and switch to the **Patcher** tab.
+2. **Choose ROM**: pick the base game file. If the ROM has a single game file, it's selected for you.
+3. **Choose patch**: pick the patch file. The patch has to be in your library, so either select an existing one (search the library, or pick from files already attached to the ROM) or **drag & drop / browse** to add a patch file first. RomM recognises a file as a patch by its `patch` category or a [supported extension](#supported-patch-formats).
+4. Optionally set an **Output filename**. If left blank, RomM derives one as `<rom> (patched-<patch>)` with the ROM's original extension.
+5. Pick what to do with the result (see [Output options](#output-options)) and hit **Apply**.
+
+The patch's source checksum is validated against the ROM. If it doesn't match, RomM still returns a file but warns you that the patched output may be incorrect.
+
+## Output options
+
+Choose one or both:
+
+- **Download patched ROM**: streams the patched file to your browser. Available to anyone who can view the ROM.
+- **Upload to RomM**: saves the patched ROM back into the library. You pick a target **platform**, RomM stores the file in that platform's folder, and a **scan starts automatically** to pick it up as a new entry.
+
+Metadata isn't inherited, so an uploaded patched ROM is **unmatched** until that scan matches it.
+
+Uploading requires write access; users without it only see the download option.
+
+## Supported patch formats
+
+| Extension | Purpose                                                  |
+| --------- | -------------------------------------------------------- |
+| `.ips`    | International Patching System. Oldest + most common.     |
+| `.ups`    | Universal Patching System. Successor to IPS.             |
+| `.bps`    | Binary Patch System. Modern, preferred for ROM hacks.    |
+| `.ppf`    | PlayStation Patch Format. For PSX/Saturn/Dreamcast ISOs. |
+| `.rup`    | Retroarch Universal Patch.                               |
+| `.aps`    | GBA-focused patch format.                                |
+| `.bdf`    | Binary diff format.                                      |
+| `.pmsr`   | Paper Mario Star Rod.                                    |
+| `.vcdiff` | Generic binary diff (xdelta).                            |
+
+If your patch has an unusual extension, try renaming to one of the above. Many are just different framings of the same underlying algorithm.
 
 ## Permissions
 
-| Action                        | User              | Admin |
-| ----------------------------- | :---------------- | :---: |
-| Use Patcher → Download        | ✓                 |   ✓   |
-| Use Patcher → Save to library | With `roms.write` |   ✓   |
+| Action                    | Scope required |
+| ------------------------- | -------------- |
+| Apply patch → download    | `roms.read`    |
+| Apply patch → upload back | `roms.write`   |
 
-Saving to the library requires the `roms.write` scope (from the user's [permission group](../administration/users-and-roles.md#permission-groups) or an override).
+Scopes come from the user's [permission group](../administration/users-and-roles.md#permission-groups) or an override; Admins can do both.
 
 ## Limits
 
-- **Browser memory**: huge ROMs (PSX/Saturn/PSP ISOs, > 1 GB) can struggle in browsers with low memory limits. Safari is the most restrictive but Firefox/Chrome can handle bigger files.
+- **File size**: the ROM and the patch must each stay under `ROM_PATCHER_MAX_FILE_SIZE_BYTES` (default **4 GiB**). patcherjs loads the whole file into memory server-side, so oversized inputs are rejected with a `400`.
 - **Multi-file ROMs**: for multi-disc games, patch each ISO separately.
 - **Encrypted ROMs**: if the patch was authored against a decrypted ROM (e.g. DS `.nds` vs raw cartridge), your source has to match.
 - **Save format changes**: patches that alter save-data layout will invalidate existing save files. Back them up before applying.
 
 ## Troubleshooting
 
-- **"Invalid patch format"**: wrong extension or corrupted file, try re-downloading the patch.
-- **"Checksum mismatch"**: the patch was built against a different ROM revision than yours, common with no-intro vs TOSEC dumps.
-- **Browser hangs on huge ROMs**: close other tabs, try Firefox, or patch outside the browser with `Floating IPS` or `BPS` CLI tools then upload the result.
-- **"Save to library" produces a broken ROM**: usually the patcher succeeded but the file was corrupted in transit.
+- **"Unsupported patch format"**: the patch extension isn't in the [supported list](#supported-patch-formats), or the file is corrupted. Try re-downloading, or rename to the correct extension.
+- **"Patch source checksum did not match the ROM"**: the patch was built against a different ROM revision than yours, common with no-intro vs TOSEC dumps. The output may be wrong even though a file was produced.
+- **`400` on apply**: usually the ROM or patch exceeds `ROM_PATCHER_MAX_FILE_SIZE_BYTES`. Raise the limit (env var) or patch outside RomM.
+- **Uploaded patched ROM stays unmatched**: expected until the automatic scan finishes matching it. Re-run a scan if it doesn't pick up.

--- a/docs/using/rom-patcher.md
+++ b/docs/using/rom-patcher.md
@@ -32,14 +32,18 @@ Two output paths:
 
 Metadata isn't inherited, so the new ROM is **unmatched** until you run a scan!
 
+<!-- prettier-ignore -->
+!!! note "Server-side patching (5.0+)"
+    RomM 5.0 can also apply a patch **on the server** and store the result directly, which sidesteps the browser-memory limits below for very large ISOs. The supported formats and permission requirements are the same as the in-browser path.
+
 ## Permissions
 
-| Action                        | Viewer | Editor | Admin |
-| ----------------------------- | :----: | :----: | :---: |
-| Use Patcher → Download        |   ✓    |   ✓    |   ✓   |
-| Use Patcher → Save to library |   -    |   ✓    |   ✓   |
+| Action                        | User              | Admin |
+| ----------------------------- | :---------------- | :---: |
+| Use Patcher → Download        | ✓                 |   ✓   |
+| Use Patcher → Save to library | With `roms.write` |   ✓   |
 
-Saving to the library requires `roms.write` scope.
+Saving to the library requires the `roms.write` scope (from the user's [permission group](../administration/users-and-roles.md#permission-groups) or an override).
 
 ## Limits
 

--- a/docs/using/uploads.md
+++ b/docs/using/uploads.md
@@ -21,8 +21,6 @@ description: Uploading ROMs
 | **Manuals**       | `roms.write`     | PDF, becomes the Manual tab content.                                 |
 | **Cover art**     | `roms.write`     | Replaces the provider-fetched cover.                                 |
 
-The `*.write` scopes come from a user's [permission group](../administration/users-and-roles.md#permission-groups) or an override; Admins can upload anything.
-
 ## ROM uploads
 
 ### Large uploads (chunked)

--- a/docs/using/uploads.md
+++ b/docs/using/uploads.md
@@ -13,13 +13,15 @@ description: Uploading ROMs
 
 | Type              | Permission       | Details                                                              |
 | ----------------- | ---------------- | -------------------------------------------------------------------- |
-| **ROMs**          | Admin, Editor    | Goes to the correct platform folder in `/romm/library`.              |
-| **Firmware/BIOS** | Admin, Editor    | See [Firmware Management](../administration/firmware-management.md). |
+| **ROMs**          | `roms.write`     | Goes to the correct platform folder in `/romm/library`.              |
+| **Firmware/BIOS** | `firmware.write` | See [Firmware Management](../administration/firmware-management.md). |
 | **Saves**         | Self (own games) | Per-ROM, per-user.                                                   |
 | **States**        | Self (own games) | Per-ROM, per-user, with optional screenshot attached.                |
 | **Screenshots**   | Self (own games) | Per-ROM, per-user.                                                   |
-| **Manuals**       | Admin, Editor    | PDF, becomes the Manual tab content.                                 |
-| **Cover art**     | Admin, Editor    | Replaces the provider-fetched cover.                                 |
+| **Manuals**       | `roms.write`     | PDF, becomes the Manual tab content.                                 |
+| **Cover art**     | `roms.write`     | Replaces the provider-fetched cover.                                 |
+
+The `*.write` scopes come from a user's [permission group](../administration/users-and-roles.md#permission-groups) or an override; Admins can upload anything.
 
 ## ROM uploads
 


### PR DESCRIPTION
## What

Updates the configuration / setup / env-var / admin surface of the docs to match [RomM 5.0.0-beta.1](https://github.com/rommapp/romm/releases/tag/5.0.0-beta.1). Verified against source at the beta tag (env template, `Role` enum, `permission.py`, `Scope` enum).

## Changes

- **Env vars** — regenerated `env-vars.md` snippet; adds `DISABLE_LOGS_VIEWER` and `OIDC_ALLOW_REGISTRATION` (only diff is those two vars).
- **Users & Roles** — full rewrite: roles collapse to **User / Admin** (Admin bypasses groups); documents the new **permission-group** model (grant matrix over 9 entities × read/write/delete, `own_only`, default group, per-user overrides, hidden platforms/ROMs). Replaced the old role-column scope matrix with an **OAuth scopes** reference (20 dotted scopes incl. the new `logs.read`).
- **Auth / OIDC / registration** — documented `OIDC_ALLOW_REGISTRATION`, reframed role mapping around User/Admin, flagged `OIDC_ROLE_VIEWER`/`OIDC_ROLE_EDITOR` as legacy no-ops (touches `authentication.md`, `invitations-and-registration.md`, `oidc/index.md`, `oidc/keycloak.md`, `oidc/zitadel.md`).
- **Observability** — added the in-app **logs viewer** gated by `DISABLE_LOGS_VIEWER` (also disables `GET /api/logs`).
- **Smaller items** — `box2d_side` media type in the config reference; Turkish (`tr_TR`) locale; glossary rewrite; swept stale Viewer/Editor references out of the developer API docs, uploads, collections, ROM patcher (+ light server-side-patching note), netplay, account/profile, and Playnite pages.

## Notes

- The permission-group UI is referenced as **Administration → Permissions** (inferred from the API router) — worth confirming against the actual beta UI.
- `env.template` still ships `OIDC_ROLE_VIEWER/EDITOR`, so the autogenerated table still lists them; their legacy behavior is covered in prose instead.

## Verification

`mkdocs build` passes with no link/anchor warnings (validated with the social-cards plugin disabled to sidestep a local `cairosvg` native-lib issue). No pages moved, so redirects are unaffected.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*