### PR TITLE
Fix Synology docker-compose example (issue #98)

### DIFF
--- a/docs/install/synology.md
+++ b/docs/install/synology.md
@@ -72,10 +72,9 @@ The Synology-flavoured compose file: MariaDB on port `3309` externally (to avoid
 
 <!-- prettier-ignore -->
 ???+ example "docker-compose.yml"
-
-<!-- `yaml
-    --8<-- "synology.docker-compose.yml"
-   ` -->
+    `yaml
+        --8<-- "synology.docker-compose.yml"
+    `
 
 Replace placeholder passwords, API keys, and `ROMM_AUTH_SECRET_KEY` with your own before starting.
 

--- a/docs/resources/snippets/synology.docker-compose.yml
+++ b/docs/resources/snippets/synology.docker-compose.yml
@@ -50,7 +50,6 @@ services:
         healthcheck:
             test: [CMD, healthcheck.sh, --connect, --innodb_initialized]
             start_period: 30s
-            start_interval: 10s
             interval: 10s
             timeout: 5s
             retries: 5


### PR DESCRIPTION
Fixes #98

## Problem

Two issues reported by a user following the Synology install guide:

1. **The docker-compose example didn't render.** The snippet include on `docs/install/synology.md` was commented out and had been dead since the file's first commit, so the page showed an empty example admonition.

2. **`start_interval` breaks validation on Synology.** The user hit `services.romm-db.healthcheck Additional property start_interval is not allowed`. Synology's Container Manager ships an older Docker Compose that doesn't support `start_interval`.

## Changes

- Uncomment the compose include and reformat it to match the working `truenas.md` / `quick-start.md` pattern (verified byte-identical to `truenas.md`). The example now renders.
- Remove `start_interval: 10s` from the Synology healthcheck. This aligns with the "simplified healthcheck" the page already advertises, and the healthcheck still works using `interval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)