### PR TITLE
Document scan.priority.region_mode

### DIFF
--- a/docs/reference/configuration-file.md
+++ b/docs/reference/configuration-file.md
@@ -224,6 +224,21 @@ scan:
             - "jp"
 ```
 
+### `scan.priority.region_mode`
+
+Controls how ScreenScraper applies `scan.priority.region` when picking regional media. With the default `prefer_rom_tags`, the region tags in the ROM's own filename win and `scan.priority.region` only reorders those tags. With `prefer_config`, the configured regions come first, so you can pull the FR box for an `(Europe)` dump even when `fr` is not in the filename, then fall back to the ROM's tags when a preferred region has no media.
+
+**Default:** `prefer_rom_tags`
+
+```yaml
+scan:
+    priority:
+        region:
+            - "fr"
+            - "eu"
+        region_mode: "prefer_config"
+```
+
 ### `scan.priority.language`
 
 Preferred localisation language.


### PR DESCRIPTION
Documents the new `scan.priority.region_mode` config key added in rommapp/romm#3917.

Adds a `scan.priority.region_mode` subsection to the configuration-file reference, right after `scan.priority.region`:

- `prefer_rom_tags` (default) keeps current behavior, where filename region tags win.
- `prefer_config` puts the configured regions first, with automatic fallback to ROM tags when a preferred region has no media.
- Short YAML example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)