### PR TITLE
docs: document MariaDB/MySQL binary logging prerequisite

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -57,7 +57,7 @@ From the directory containing your `docker-compose.yml`:
 docker compose up -d
 ```
 
-On the first run Docker will pull `rommapp/romm:latest` and `mariadb:latest`, bring up the database, wait for the healthcheck, then bring up the app. Verify everything is running:
+On the first run Docker will pull `rommapp/romm:latest` and `mariadb:latest`, bring up the database, wait for the healthcheck, then bring up the app. If you dropped the `romm-db` service and pointed RomM at a MariaDB or MySQL server you already run, read the [binary logging prerequisite](../install/databases.md#binary-logging-and-trigger-privileges) first, because migrations fail at startup without it. Verify everything is running:
 
 ```sh
 docker ps -f name=romm

--- a/docs/install/databases.md
+++ b/docs/install/databases.md
@@ -10,7 +10,7 @@ RomM uses SQLAlchemy + Alembic for persistence. Three drivers are supported, so 
 | Driver                             | `ROMM_DB_DRIVER` | Image         | Default port | Notes                                          |
 | ---------------------------------- | ---------------- | ------------- | ------------ | ---------------------------------------------- |
 | **MariaDB** (default, recommended) | `mariadb`        | `mariadb:11`  | `3306`       | What the reference compose uses. Well-tested.  |
-| **MySQL**                          | `mysql`          | `mysql:8`     | `3306`       | Largely interchangeable with MariaDB for RomM. |
+| **MySQL**                          | `mysql`          | `mysql:8`     | `3306`       | Largely interchangeable with MariaDB for RomM, but see [binary logging](#binary-logging-and-trigger-privileges). |
 | **PostgreSQL**                     | `postgresql`     | `postgres:16` | `5432`       | Use if you already run Postgres.               |
 
 ## MariaDB (default)
@@ -65,6 +65,41 @@ services:
             timeout: 5s
             retries: 5
 ```
+
+## Binary logging and trigger privileges
+
+RomM's migrations create triggers on the `roms` table. MariaDB and MySQL refuse trigger DDL when binary logging is enabled and the connecting user lacks `SUPER`, so the container aborts during startup with:
+
+```
+sqlalchemy.exc.OperationalError: (mariadb.OperationalError) You do not have the SUPER
+privilege and binary logging is enabled (you *might* want to use the less safe
+log_bin_trust_function_creators variable)
+ERROR:    [RomM][init] Failed to run database migrations
+```
+
+This mainly affects external or managed database servers, because binary logging is on by default on MySQL 8 and is commonly enabled on hardened or replicated MariaDB instances. The `mariadb:11` container from the reference Compose is not affected out of the box.
+
+Both fixes below have to be applied by an admin or root database user rather than the RomM user. The quickest one sets the global flag, though it is lost when the database restarts:
+
+```sql
+SET GLOBAL log_bin_trust_function_creators = 1;
+```
+
+To make it survive a restart, add it under `[mysqld]` in the server's option file and restart the database (see [Configuring MariaDB with option files](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/configuring-mariadb/configuring-mariadb-with-option-files)). That file is usually `my.cnf`, or `custom.cnf` under `/config` on the linuxserver image:
+
+```cnf
+[mysqld]
+log_bin_trust_function_creators = 1
+```
+
+Alternatively, grant the privilege to the RomM user itself:
+
+```sql
+GRANT BINLOG ADMIN ON *.* TO 'romm-user'@'%';  -- MariaDB 10.5+
+GRANT SUPER ON *.* TO 'romm-user'@'%';         -- older MariaDB, or MySQL
+```
+
+Restart RomM once the change is in place. A migration that failed this way is safe to re-run, so it picks up from wherever it stopped and completes.
 
 ## PostgreSQL
 

--- a/docs/install/databases.md
+++ b/docs/install/databases.md
@@ -7,11 +7,11 @@ description: Supported database drivers
 
 RomM uses SQLAlchemy + Alembic for persistence. Three drivers are supported, so pick based on what you already run.
 
-| Driver                             | `ROMM_DB_DRIVER` | Image         | Default port | Notes                                          |
-| ---------------------------------- | ---------------- | ------------- | ------------ | ---------------------------------------------- |
-| **MariaDB** (default, recommended) | `mariadb`        | `mariadb:11`  | `3306`       | What the reference compose uses. Well-tested.  |
+| Driver                             | `ROMM_DB_DRIVER` | Image         | Default port | Notes                                                                                                            |
+| ---------------------------------- | ---------------- | ------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| **MariaDB** (default, recommended) | `mariadb`        | `mariadb:11`  | `3306`       | What the reference compose uses. Well-tested.                                                                    |
 | **MySQL**                          | `mysql`          | `mysql:8`     | `3306`       | Largely interchangeable with MariaDB for RomM, but see [binary logging](#binary-logging-and-trigger-privileges). |
-| **PostgreSQL**                     | `postgresql`     | `postgres:16` | `5432`       | Use if you already run Postgres.               |
+| **PostgreSQL**                     | `postgresql`     | `postgres:16` | `5432`       | Use if you already run Postgres.                                                                                 |
 
 ## MariaDB (default)
 
@@ -70,7 +70,7 @@ services:
 
 RomM's migrations create triggers on the `roms` table. MariaDB and MySQL refuse trigger DDL when binary logging is enabled and the connecting user lacks `SUPER`, so the container aborts during startup with:
 
-```
+```text
 sqlalchemy.exc.OperationalError: (mariadb.OperationalError) You do not have the SUPER
 privilege and binary logging is enabled (you *might* want to use the less safe
 log_bin_trust_function_creators variable)

--- a/docs/install/databases.md
+++ b/docs/install/databases.md
@@ -7,11 +7,11 @@ description: Supported database drivers
 
 RomM uses SQLAlchemy + Alembic for persistence. Three drivers are supported, so pick based on what you already run.
 
-| Driver                             | `ROMM_DB_DRIVER` | Image         | Default port | Notes                                                                                                            |
-| ---------------------------------- | ---------------- | ------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| **MariaDB** (default, recommended) | `mariadb`        | `mariadb:11`  | `3306`       | What the reference compose uses. Well-tested.                                                                    |
-| **MySQL**                          | `mysql`          | `mysql:8`     | `3306`       | Largely interchangeable with MariaDB for RomM, but see [binary logging](#binary-logging-and-trigger-privileges). |
-| **PostgreSQL**                     | `postgresql`     | `postgres:16` | `5432`       | Use if you already run Postgres.                                                                                 |
+| Driver                             | `ROMM_DB_DRIVER` | Image         | Default port | Notes                                          |
+| ---------------------------------- | ---------------- | ------------- | ------------ | ---------------------------------------------- |
+| **MariaDB** (default, recommended) | `mariadb`        | `mariadb:11`  | `3306`       | What the reference compose uses. Well-tested.  |
+| **MySQL**                          | `mysql`          | `mysql:8`     | `3306`       | Largely interchangeable with MariaDB for RomM. |
+| **PostgreSQL**                     | `postgresql`     | `postgres:16` | `5432`       | Use if you already run Postgres.               |
 
 ## MariaDB (default)
 

--- a/docs/install/unraid.md
+++ b/docs/install/unraid.md
@@ -34,7 +34,7 @@ docker network ls  # confirm `romm` is listed
 
 1. Install MariaDB
 
-From **Apps** → search `mariadb`. Only the [official `mariadb`](https://hub.docker.com/_/mariadb) and [linuxserver/docker-mariadb](https://github.com/linuxserver/docker-mariadb/pkgs/container/mariadb) templates are supported. **Prefer the official one.**
+From **Apps** → search `mariadb`. Only the [official `mariadb`](https://hub.docker.com/_/mariadb) and [linuxserver/docker-mariadb](https://github.com/linuxserver/docker-mariadb/pkgs/container/mariadb) templates are supported. **Prefer the official one.** If you point RomM at an existing MariaDB or MySQL server instead, check the [binary logging prerequisite](databases.md#binary-logging-and-trigger-privileges) before starting the app.
 
 ![community apps search results for MariaDB](https://github.com/user-attachments/assets/76f4b6ef-5b63-454f-9357-d2920b9afd0e)
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -9,6 +9,7 @@ description: Diagnose common issues by symptom
 
 - Container crashes immediately → check `docker logs romm`. If it's `invalid host in "tcp://..."` you're on Kubernetes, see [Kubernetes Troubleshooting](kubernetes.md).
 - Database connection errors → verify `DB_HOST`/`DB_PASSWD` match your DB container, and that the DB has finished initialising (first run takes longer than you'd think).
+- `Failed to run database migrations` with `You do not have the SUPER privilege and binary logging is enabled` → your MariaDB/MySQL server needs `log_bin_trust_function_creators = 1`, or the RomM database user needs the privilege granted (see [Databases → Binary logging and trigger privileges](../install/databases.md#binary-logging-and-trigger-privileges)).
 - "Page not found" on first load → wait, because initial migrations and resource seeding take a minute.
 
 ## No Setup Wizard


### PR DESCRIPTION
Users pointing RomM at an external or managed MariaDB/MySQL server hit a hard startup failure when binary logging is enabled and the RomM DB user lacks `SUPER`: the migrations that create triggers on the `roms` table are refused, and the container dies with a raw SQLAlchemy traceback. This was never documented, so affected users had nothing to search for.

- `install/databases.md`: new **Binary logging and trigger privileges** section with the error text, why it affects external servers (binlog is on by default on MySQL 8) and not the bundled `mariadb:11`, and the fixes: `SET GLOBAL log_bin_trust_function_creators = 1`, the persistent `[mysqld]` option-file version (including `custom.cnf` under `/config` on the linuxserver image), or a `BINLOG ADMIN` / `SUPER` grant.
- `troubleshooting/index.md`: symptom bullet under "RomM won't start" linking to the above.
- `getting-started/quick-start.md`: one line for people who drop the `romm-db` service and use their own server.
- `install/unraid.md`: pointer next to the MariaDB template step.

Refs https://github.com/rommapp/romm/issues/3932 (fix guidance from https://github.com/rommapp/romm/issues/3932#issuecomment-5138930651 and the surrounding thread).

Verified with `mkdocs build --strict` (social plugin disabled locally, missing libcairo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)