### PR TITLE
docs: add js-dos player for Windows 3.x / 9x

### DIFF
--- a/docs/Navigation.md
+++ b/docs/Navigation.md
@@ -50,6 +50,7 @@ search:
     - [Uploads](using/uploads.md)
     - In-Browser Play
         - [EmulatorJS](using/in-browser-play/emulatorjs.md)
+        - [`js-dos`](using/in-browser-play/js-dos.md)
         - [MS-DOS](using/in-browser-play/ms-dos.md)
         - [Ruffle](using/in-browser-play/ruffle.md)
     - [Emulator Streaming](using/emulator-streaming.md)

--- a/docs/about/credits.md
+++ b/docs/about/credits.md
@@ -35,6 +35,8 @@ This stack stands on an enormous amount of open-source work. In rough order of "
 ### In-browser emulation
 
 - [EmulatorJS](https://emulatorjs.org/)
+- [`js-dos`](https://js-dos.com/)
+- [DOSBox-X](https://dosbox-x.com/)
 - [Ruffle](https://ruffle.rs/)
 - [dosbox-pure](https://github.com/schellingb/dosbox-pure)
 

--- a/docs/about/license.md
+++ b/docs/about/license.md
@@ -34,7 +34,7 @@ Companion repos use more permissive licenses AGPLv3 or MIT because they're small
 
 ## Third-party components
 
-Several third-party components ship with their own licenses: [EmulatorJS](https://emulatorjs.org/), [Ruffle](https://ruffle.rs/), Vue, FastAPI, and a long list of smaller dependencies. Their licenses apply to their respective code, and none of them override AGPLv3 on the RomM code itself. View the full list via `uv tree` in the backend and `npm ls` in the frontend. Redistribution respects each upstream's terms.
+Several third-party components ship with their own licenses: [EmulatorJS](https://emulatorjs.org/), [`js-dos`](https://js-dos.com/), [Ruffle](https://ruffle.rs/), Vue, FastAPI, and a long list of smaller dependencies. Their licenses apply to their respective code, and none of them override AGPLv3 on the RomM code itself. View the full list via `uv tree` in the backend and `npm ls` in the frontend. Redistribution respects each upstream's terms.
 
 ## FAQ
 

--- a/docs/install/image-variants.md
+++ b/docs/install/image-variants.md
@@ -5,12 +5,12 @@ description: Choose between the slim and full container images
 
 # Image Variants
 
-RomM publishes two production image variants. They're interchangeable at the config level, so pick based on whether you want baked-in EmulatorJS cores or fetch them from the CDN at runtime.
+RomM publishes two production image variants. They're interchangeable at the config level, so pick based on whether you want browser emulator assets bundled into the image.
 
-| Variant            | Tag                                           | Approx size | When to pick                                                                             |
-| ------------------ | --------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| **Full** (default) | `rommapp/romm:latest` `rommapp/romm:5.0.0`    | ~400MB      | You want in-browser play (most users pick this).                                         |
-| **Slim**           | `rommapp/romm:slim` `rommapp/romm:5.0.0-slim` | ~100MB      | Headless use (API + native-app clients only) or when you're running emulators elsewhere. |
+| Variant            | Tag                                           | Approx size | When to pick                                                                                      |
+| ------------------ | --------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------- |
+| **Full** (default) | `rommapp/romm:latest` `rommapp/romm:5.0.0`    | ~400MB      | You want bundled in-browser players, including `js-dos` (most users pick this).                      |
+| **Slim**           | `rommapp/romm:slim` `rommapp/romm:5.0.0-slim` | ~100MB      | You can use the EmulatorJS CDN or run emulators elsewhere. `js-dos` is not available in this image. |
 
 Both variants are published on Docker Hub (`docker.io/rommapp/romm`) and GitHub Container Registry (`ghcr.io/rommapp/romm`). The GHCR images track the same tags and are a good choice if you run into Docker Hub's rate limits.
 

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -10,6 +10,6 @@ description: Everything about the supported platforms
 
 ## Related sections
 
-- **[In-Browser Play](../using/in-browser-play/emulatorjs.md)**: the end-user side of EmulatorJS + Ruffle
+- **[In-Browser Play](../using/in-browser-play/emulatorjs.md)**: the end-user side of EmulatorJS, `js-dos`, and Ruffle
 - **[Metadata Providers](../getting-started/metadata-providers.md)**
 - **[Folder Structure](../getting-started/folder-structure.md)**

--- a/docs/using/in-browser-play/js-dos.md
+++ b/docs/using/in-browser-play/js-dos.md
@@ -1,0 +1,51 @@
+---
+title: js-dos
+description: Play Windows 3.x and 9x games in the browser via DOSBox-X
+---
+
+# `js-dos`
+
+[`js-dos`](https://js-dos.com/) runs DOSBox-X in the browser for Windows 3.x (`win3x`) and Windows 9x (`win9x`) titles. MS-DOS games continue to use the [EmulatorJS `dosbox-pure` core](ms-dos.md).
+
+<!-- prettier-ignore -->
+!!! important "The full image is required"
+    `js-dos` is bundled only with RomM's full container image. The slim image has no `js-dos` CDN fallback. See [Image Variants](../../install/image-variants.md).
+
+## Bundling a game
+
+RomM passes the selected file directly to `js-dos`, so upload a ready-to-run [`js-dos` bundle](https://js-dos.com/jsdos-bundle.html), not a regular zip of loose game files. The bundle is a zip with a required `.jsdos/dosbox.conf`:
+
+```text
+game.zip
+    .jsdos/
+        dosbox.conf
+    WINDOWS/
+    ...game files
+```
+
+The configuration controls how the bundle boots. For example, a Windows 3.x bundle with Windows installed in the zip root can use:
+
+```ini
+[dosbox]
+machine=svga_s3
+memsize=32
+
+[autoexec]
+echo off
+mount c .
+c:
+WIN GAMEDIR\GAME
+```
+
+- `mount c .` mounts the bundle root as `C:`. `js-dos` does not add this mount automatically.
+- `WIN GAMEDIR\GAME` boots Windows straight into the game instead of Program Manager.
+
+Windows 9x and disk-image layouts need different DOSBox-X configuration. Use the [`js-dos` bundle cookbook](https://js-dos.com/jsdos-bundle.html) or [`js-dos` Game Studio](https://v8.js-dos.com/studio/), its browser-based bundle builder. Upload the result under the `win3x` or `win9x` platform. RomM uses `js-dos` only for those platforms and leaves `dos` with EmulatorJS.
+
+## Saves
+
+`js-dos` stores filesystem changes in the browser, isolated by RomM user and game. They are not uploaded or synced with RomM. Use **Quit** and wait for the final save before leaving the player.
+
+<!-- prettier-ignore -->
+!!! warning "Saving depends on the application"
+    Some applications save only when you exit back to Windows. Exit the application before quitting the player.

--- a/docs/using/in-browser-play/ms-dos.md
+++ b/docs/using/in-browser-play/ms-dos.md
@@ -10,6 +10,10 @@ description: Run DOS games in the browser via dosbox-pure
 DOS games run via the `dosbox-pure` core (part of [EmulatorJS](emulatorjs.md)). Create a DOS platform (folder named `dos`) and drop your games in. Operator tuning lives in [Configuration File → `emulatorjs`](../../reference/configuration-file.md#emulatorjs) (notably `disable_batch_bootup` for DOS-specific issues).
 
 <!-- prettier-ignore -->
+!!! info "Windows 3.x and 9x games use `js-dos`"
+    RomM keeps DOS games on `dosbox-pure` and routes Windows 3.x and 9x titles through the [`js-dos` player](js-dos.md). Put those titles under the `win3x` and `win9x` platform folders instead of `dos`.
+
+<!-- prettier-ignore -->
 !!! tip "Upload games as `.zip`"
     `dosbox-pure` knows how to unzip and auto-mount zipped DOS games, which is much easier than packaging a raw folder.
 

--- a/docs/using/index.md
+++ b/docs/using/index.md
@@ -9,6 +9,7 @@ description: Browse, play, collect, patch, and share from the UI
 
 - **[EmulatorJS](in-browser-play/emulatorjs.md)**
     - **[MS-DOS](in-browser-play/ms-dos.md)**
+- **[`js-dos`](in-browser-play/js-dos.md)**
 - **[Ruffle](in-browser-play/ruffle.md)**
 - **[Emulator Streaming](emulator-streaming.md)**
 - **[Downloads](downloads.md)**


### PR DESCRIPTION
Documents the new `js-dos` player for Windows 3.x and Windows 9x titles (https://github.com/rommapp/romm/pull/4061).

Changes:
- Required `js-dos` bundle structure and a Windows 3.x example
- Browser-local save behavior
- Full-image requirement
- Clear separation from MS-DOS support in EmulatorJS
- Navigation, image variant, and attribution updates

AI assistance was used to review, simplify, and verify the documentation.