### PR TITLE
docs: add NixOS install guide

### DIFF
--- a/docs/Navigation.md
+++ b/docs/Navigation.md
@@ -22,6 +22,7 @@ search:
     - [TrueNAS](install/truenas.md)
     - [Kubernetes](install/kubernetes.md)
     - [Railway](install/railway.md)
+    - [NixOS](install/nixos.md)
     - [Backup & Restore](install/backup-and-restore.md)
 - Administration
     - [Overview](administration/index.md)

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1,11 +1,11 @@
 ---
 title: Install & Deploy
-description: On Docker Compose, Unraid, Synology, TrueNAS, Kubernetes, or Railway
+description: On Docker Compose, Unraid, Synology, TrueNAS, Kubernetes, Railway, or NixOS
 ---
 
 # Install & Deploy
 
-RomM is distributed as a Docker image. Every supported deployment runs the same container, and the differences are in who manages it.
+RomM is distributed as a Docker image. Every supported deployment runs the same container, and the differences are in who manages it. The exception is [NixOS](nixos.md), which packages RomM natively.
 
 ## Pick your path
 

--- a/docs/install/nixos.md
+++ b/docs/install/nixos.md
@@ -5,7 +5,7 @@ description: Install RomM natively on NixOS via the services.romm module
 
 # NixOS
 
-Unlike the other platforms in this section, NixOS doesn't run the Docker image: RomM is packaged natively in [nixpkgs](https://github.com/NixOS/nixpkgs), with a NixOS module that sets up the whole stack — the backend services, PostgreSQL, Redis, and an nginx virtual host that mirrors what upstream's container image does (frontend, streamed ZIP downloads via `mod_zip`, and the cross-origin isolation headers the in-browser emulator needs).
+Unlike the other platforms in this section, NixOS doesn't run the Docker image: RomM is packaged natively in [nixpkgs](https://github.com/NixOS/nixpkgs). The `services.romm` module sets up everything RomM needs — the RomM services themselves, a database, Redis, and a web server — from a few lines of configuration.
 
 <!-- prettier-ignore -->
 !!! note "Availability"
@@ -30,14 +30,7 @@ You'll need:
 }
 ```
 
-That single block gives you, after a `nixos-rebuild switch`:
-
-- The `romm`, `romm-worker`, `romm-scheduler` and `romm-watcher` systemd services, running as the `romm` system user
-- A local **PostgreSQL** database with peer authentication (no password to manage)
-- A dedicated local **Redis** instance for sessions and the task queue
-- An **nginx** virtual host serving the frontend and proxying the API
-- `RAHasher` on the services' `PATH` for RetroAchievements hashing
-- An auto-generated `ROMM_AUTH_SECRET_KEY`, persisted under the data directory
+After a `nixos-rebuild switch`, RomM is up on that domain with everything included: a local PostgreSQL database and Redis instance (no credentials to manage), an nginx virtual host serving the app, and in-browser play, streamed downloads and RetroAchievements hashing all working out of the box.
 
 <!-- prettier-ignore -->
 !!! note "PostgreSQL, not MariaDB"
@@ -94,11 +87,11 @@ services.nginx.virtualHosts."romm.example.org" = {
 };
 ```
 
-The module picks up TLS on the virtual host automatically and sets `ROMM_BASE_URL` and secure session cookies accordingly. If you terminate TLS on a different machine instead, point your external [reverse proxy](reverse-proxy.md) at this host's virtual host.
+The module detects TLS on the virtual host and configures RomM accordingly — no extra settings needed. If you terminate TLS on a different machine instead, point your external [reverse proxy](reverse-proxy.md) at this host's virtual host.
 
 ## Library location
 
-Upstream fixes the library to `<data dir>/library`, which on NixOS defaults to `/var/lib/romm/library`. To use an existing collection stored elsewhere, bind-mount it there:
+RomM expects the library at `/var/lib/romm/library`. To use an existing collection stored elsewhere, bind-mount it there:
 
 ```nix
 fileSystems."/var/lib/romm/library" = {
@@ -107,7 +100,7 @@ fileSystems."/var/lib/romm/library" = {
 };
 ```
 
-Make sure the mounted collection is readable and writable by the `romm` user. The filesystem watcher rescans the library on changes by default (`services.romm.watcher.enable`).
+Make sure the mounted collection is readable and writable by the `romm` user. Changes to the library are picked up automatically.
 
 ## External database or Redis
 
@@ -119,7 +112,7 @@ The full set of module options is documented in the NixOS options search: [`serv
 
 ## Updating
 
-RomM updates arrive with your channel: `nixos-rebuild switch --upgrade` (or your flake update workflow) picks up new versions, and database migrations run automatically before the service starts.
+RomM updates arrive with your channel: `nixos-rebuild switch --upgrade` (or your flake update workflow) picks up new versions, and database migrations run automatically.
 
 ## Troubleshooting
 

--- a/docs/install/nixos.md
+++ b/docs/install/nixos.md
@@ -1,0 +1,128 @@
+---
+title: NixOS
+description: Install RomM natively on NixOS via the services.romm module
+---
+
+# NixOS
+
+Unlike the other platforms in this section, NixOS doesn't run the Docker image: RomM is packaged natively in [nixpkgs](https://github.com/NixOS/nixpkgs), with a NixOS module that sets up the whole stack — the backend services, PostgreSQL, Redis, and an nginx virtual host that mirrors what upstream's container image does (frontend, streamed ZIP downloads via `mod_zip`, and the cross-origin isolation headers the in-browser emulator needs).
+
+<!-- prettier-ignore -->
+!!! note "Availability"
+    RomM was recently merged into nixpkgs `master`, so it can take a little while to land in the `nixos-unstable` channel. It will be part of the next stable release (NixOS 26.11); whether it gets backported to 26.05 is not decided. You can check which channels have it on [search.nixos.org](https://search.nixos.org/packages?query=romm).
+
+## Before you start
+
+You'll need:
+
+- A NixOS system on a channel that includes the `romm` package (see the note above)
+- Your ROM files organised in the expected [folder structure](../getting-started/folder-structure.md)
+- API credentials for at least one [metadata provider](../getting-started/metadata-providers.md)
+
+## Minimal configuration
+
+```nix
+{
+  services.romm = {
+    enable = true;
+    nginx.virtualHost = "romm.example.org";
+  };
+}
+```
+
+That single block gives you, after a `nixos-rebuild switch`:
+
+- The `romm`, `romm-worker`, `romm-scheduler` and `romm-watcher` systemd services, running as the `romm` system user
+- A local **PostgreSQL** database with peer authentication (no password to manage)
+- A dedicated local **Redis** instance for sessions and the task queue
+- An **nginx** virtual host serving the frontend and proxying the API
+- `RAHasher` on the services' `PATH` for RetroAchievements hashing
+- An auto-generated `ROMM_AUTH_SECRET_KEY`, persisted under the data directory
+
+<!-- prettier-ignore -->
+!!! note "PostgreSQL, not MariaDB"
+    The NixOS module uses PostgreSQL rather than the MariaDB default of the Docker setup. If you're migrating an existing instance from Docker, see [Backup & Restore](backup-and-restore.md) — you can't reuse a MariaDB dump directly.
+
+Don't forget to open the firewall if the machine should be reachable from elsewhere:
+
+```nix
+networking.firewall.allowedTCPPorts = [
+  80
+  443
+];
+```
+
+## Metadata provider credentials
+
+Secrets don't belong in the Nix store, so provider credentials go into an environment file readable only by root:
+
+```nix
+{
+  services.romm = {
+    enable = true;
+    nginx.virtualHost = "romm.example.org";
+    environmentFile = "/run/secrets/romm.env";
+  };
+}
+```
+
+With `/run/secrets/romm.env` (deployed via [sops-nix](https://github.com/Mic92/sops-nix), [agenix](https://github.com/ryantm/agenix), or by hand) containing the usual RomM variables:
+
+```bash
+IGDB_CLIENT_ID=xxxx
+IGDB_CLIENT_SECRET=yyyy
+SCREENSCRAPER_USER=zzzz
+SCREENSCRAPER_PASSWORD=wwww
+```
+
+Non-secret settings can go straight into your configuration via `extraEnvironment`, which accepts any of RomM's [environment variables](../reference/environment-variables.md):
+
+```nix
+services.romm.extraEnvironment = {
+  WEB_CONCURRENCY = "4";
+};
+```
+
+## HTTPS
+
+The virtual host is a regular NixOS nginx virtual host, so TLS is the standard one-liner away (HTTPS is required for OIDC and PWA install):
+
+```nix
+services.nginx.virtualHosts."romm.example.org" = {
+  enableACME = true;
+  forceSSL = true;
+};
+```
+
+The module picks up TLS on the virtual host automatically and sets `ROMM_BASE_URL` and secure session cookies accordingly. If you terminate TLS on a different machine instead, point your external [reverse proxy](reverse-proxy.md) at this host's virtual host.
+
+## Library location
+
+Upstream fixes the library to `<data dir>/library`, which on NixOS defaults to `/var/lib/romm/library`. To use an existing collection stored elsewhere, bind-mount it there:
+
+```nix
+fileSystems."/var/lib/romm/library" = {
+  device = "/tank/roms";
+  options = [ "bind" ];
+};
+```
+
+Make sure the mounted collection is readable and writable by the `romm` user. The filesystem watcher rescans the library on changes by default (`services.romm.watcher.enable`).
+
+## External database or Redis
+
+`services.romm.database.createLocally` and `services.romm.redis.createLocally` default to `true`. Set them to `false` to use an existing PostgreSQL or Redis instance, and configure `services.romm.database.{host,port,name,user}` / `services.romm.redis.{host,port}` accordingly. Credentials for remote instances (`DB_PASSWD`, `REDIS_PASSWORD`) belong in the `environmentFile`.
+
+## All options
+
+The full set of module options is documented in the NixOS options search: [`services.romm.*`](https://search.nixos.org/options?channel=unstable&query=services.romm).
+
+## Updating
+
+RomM updates arrive with your channel: `nixos-rebuild switch --upgrade` (or your flake update workflow) picks up new versions, and database migrations run automatically before the service starts.
+
+## Troubleshooting
+
+- Check the services: `systemctl status romm romm-worker romm-scheduler romm-watcher`
+- Follow the logs: `journalctl -fu romm`
+- Scan issues are usually permissions on the library path — everything under `/var/lib/romm` must be readable and writable by the `romm` user.


### PR DESCRIPTION
Adds an install guide for running RomM natively on NixOS via the `services.romm` NixOS module, and links it from the Install & Deploy overview and the nav sidebar.

> [!IMPORTANT]
> **Please don't merge this yet.** The RomM package and module are still under review in nixpkgs: NixOS/nixpkgs#547607. This PR should only be merged once that one has landed in nixpkgs `master`, so the docs never describe something that doesn't exist yet. I'll drop a comment here when it's in.

The guide covers a minimal configuration, metadata provider credentials via an environment file, HTTPS, using an existing ROM library, external database/Redis, updates, and basic troubleshooting. It also notes that availability starts with `nixos-unstable` (stable with NixOS 26.11), and that the module uses PostgreSQL rather than MariaDB.

Verified with `mkdocs build --strict` and prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)