### PR TITLE
docs(igir): use --merge-discs and playlist, and document CHD handling

### DIFF
--- a/docs/ecosystem/igir.md
+++ b/docs/ecosystem/igir.md
@@ -60,6 +60,7 @@ OUTPUT_DIR=roms-verified
 time npx -y igir@latest \
   move \
   extract \
+  playlist \
   report \
   test \
   -d dats/ \
@@ -68,7 +69,8 @@ time npx -y igir@latest \
   --input-checksum-quick false \
   --input-checksum-min CRC32 \
   --input-checksum-max SHA256 \
-  --only-retail
+  --only-retail \
+  --merge-discs
 ```
 
 Make it executable:
@@ -97,42 +99,77 @@ npx -y igir@latest \
 
 This keeps the original subfolder structure but normalises extensions.
 
-## Multi-disc reorganisation
+## Multi-disc games
 
-Igir outputs multi-disc games as separate folders, which confuses multi-file game detection. Collapse them:
+Redump and No-Intro catalogue each disc of a multi-disc game as a separate game, so by default Igir writes them out as sibling folders — which confuses multi-file game detection. Two parts of the script above handle this, no manual reorganisation needed:
 
-```sh
-cd roms-verified/psx
-
-ls -d *Disc* | while read file; do
-    game=$(echo "${file}" | sed -E 's/ ?\(Disc.*//')
-    mkdir -p "${game}"
-    mv "${file}" "${game}"
-    m3u="${game}/${game}.m3u"
-    touch "${m3u}"
-    echo "${file}" >> "${m3u}"
-done
-```
+- `--merge-discs` groups the discs of a game back into a single folder.
+- The `playlist` command writes an `.m3u` alongside them.
 
 Before:
 
 ```text
-Final Fantasy VII (Disc 1) (USA)/
-Final Fantasy VII (Disc 2) (USA)/
-Final Fantasy VII (Disc 3) (USA)/
+Final Fantasy VII (USA) (Disc 1)/
+Final Fantasy VII (USA) (Disc 2)/
+Final Fantasy VII (USA) (Disc 3)/
 ```
 
 After:
 
 ```text
 Final Fantasy VII (USA)/
-  Final Fantasy VII (Disc 1) (USA)/
-  Final Fantasy VII (Disc 2) (USA)/
-  Final Fantasy VII (Disc 3) (USA)/
+  Final Fantasy VII (USA) (Disc 1)/
+  Final Fantasy VII (USA) (Disc 2)/
+  Final Fantasy VII (USA) (Disc 3)/
   Final Fantasy VII (USA).m3u
 ```
 
-The `.m3u` is a playlist RomM respects for launching multi-disc games.
+The `.m3u` is a playlist RomM respects for launching multi-disc games. It holds a relative path to each disc's playable file, in disc order:
+
+```text
+Final Fantasy VII (USA) (Disc 1)/Final Fantasy VII (USA) (Disc 1).cue
+Final Fantasy VII (USA) (Disc 2)/Final Fantasy VII (USA) (Disc 2).cue
+Final Fantasy VII (USA) (Disc 3)/Final Fantasy VII (USA) (Disc 3).cue
+```
+
+A few things worth knowing:
+
+- A playlist points at each disc's playable file, so discs can't be sitting inside zip archives — that's why the script uses `extract` rather than `zip` for these platforms. The extensions Igir will reference default to `.ccd`, `.cdi`, `.chd`, `.cue`, `.gdi`, `.iso`, `.mdf`, and `.toc`, adjustable with `--playlist-extensions`.
+- CHDs need no special handling to appear in a playlist, though the script as written will unpack them — see [Keeping CHDs as CHDs](#keeping-chds-as-chds).
+- Playlists are only written for multi-disc games. If you want one for every game, add `--playlist-mode always`.
+- `--merge-discs` doesn't require DAT files, but is far more reliable with them — the script already passes `-d dats/`.
+- Some TOSEC-catalogued discs won't merge, because the ring/box codes used to distinguish separate pressings can't be told apart from other metadata programmatically. See Igir's [merging limitations](https://igir.io/roms/sets/#merging-limitations).
+
+## Keeping CHDs as CHDs
+
+Igir reads inside a CHD to identify its tracks, but `extract` will unpack it into those tracks — `.cue`/`.bin`, or `.gdi` — rather than leaving the CHD intact. This applies to single-disc games as much as multi-disc ones.
+
+`extract` applies to the whole run, so dropping it to protect your CHDs would also stop cartridge ROMs being unzipped. Split the run in two instead, excluding CHDs from the pass that extracts and handling them in a second pass that copies them through untouched:
+
+```bash
+# Everything except CHDs, extracted
+npx -y igir@latest \
+  move extract playlist report test \
+  -d dats/ \
+  -i "${INPUT_DIR}/" \
+  -I "${INPUT_DIR}/**/*.chd" \
+  -o "${OUTPUT_DIR}/{romm}/" \
+  --only-retail \
+  --merge-discs
+
+# CHDs, left as they are
+npx -y igir@latest \
+  move playlist report test \
+  -d dats/ \
+  -i "${INPUT_DIR}/**/*.chd" \
+  -o "${OUTPUT_DIR}/{romm}/" \
+  --only-retail \
+  --merge-discs
+```
+
+Each game's discs are either all CHDs or all not, so disc grouping and playlists still come out right despite the split.
+
+Matching CHDs against DATs is slower on the first run, since a CHD carries only a SHA1 rather than per-file CRC32. Igir caches the results, so subsequent runs are much faster.
 
 ## Importing
 


### PR DESCRIPTION
## Multi-disc games

The section had readers run a shell loop over `roms-verified/psx` to collapse disc folders and hand-write `.m3u` files. Igir does both natively, so this replaces the loop with `--merge-discs` and the `playlist` command in the existing cleanup script.

Beyond being shorter, this fixes a few problems with the manual approach:

- The generated `.m3u` listed directory names rather than paths to the `.cue`/`.gdi` inside them, which most frontends won't load. Igir writes the full relative path.
- Disc order depended on `ls` ordering; Igir sorts by disc.
- The loop was PS1-only and had to be rerun per platform. Igir handles Saturn, Dreamcast, Mega CD, etc. in the same pass.
- The `sed` pattern dropped trailing metadata on TOSEC-style names: `(Disc 1 of 2)[!]` lost the `[!]`.

It also picks up the caveats worth knowing: which disc formats a playlist can point at, `--playlist-mode always` for single-disc games, DATs improving merge reliability, and TOSEC ring/box codes that won't merge.

## Keeping CHDs as CHDs

New section. The cleanup script's `extract` unpacks a CHD into its `.cue`/`.bin` tracks, which is surprising if you deliberately built a CHD library — and `extract` can't simply be dropped, since it's what unzips cartridge ROMs in the same run. The section shows splitting it into two passes with `--input-exclude`, and notes the slower first-run DAT matching on CHDs, which carry only a SHA1 rather than per-file CRC32.

This is its own top-level section rather than part of Multi-disc games, since it applies to single-disc CHDs equally.

## Incidental

The before/after trees had the disc token in the wrong position — Redump writes `Final Fantasy VII (USA) (Disc 1)`, not `Final Fantasy VII (Disc 1) (USA)`.

The heading changed from "Multi-disc reorganisation" to "Multi-disc games", so the anchor moves from `#multi-disc-reorganisation` to `#multi-disc-games`. Nothing in the docs links to the old anchor.